### PR TITLE
feat: Implement query builder with insert functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jone
 
-A Go database migration tool with a fluent schema builder. Supports PostgreSQL and MySQL.
+A Go database query builder. Supports PostgreSQL and MySQL.
 
 ## 📦 Installation
 
@@ -82,6 +82,8 @@ var Config = jone.Config{
         TableName: "jone_migrations",
     },
 }
+
+var DB = jone.New(&Config)
 ```
 
 **MySQL:**
@@ -106,6 +108,8 @@ var Config = jone.Config{
         TableName: "jone_migrations",
     },
 }
+
+var DB = jone.New(&Config)
 ```
 
 ## 🔗 Connection Pooling
@@ -272,6 +276,45 @@ s.Raw("CREATE INDEX CONCURRENTLY idx_users_email ON users(email)")
 // Data migrations with parameters
 s.Raw("INSERT INTO settings (key, value) VALUES ($1, $2)", "version", "1.0")
 s.Raw("UPDATE users SET status = $1 WHERE created_at < $2", "legacy", "2020-01-01")
+```
+
+## 🔍 Query Builder
+
+Jone includes a Knex-inspired query builder. The database connection is lazy — it connects automatically on first query. See [QUERYBUILDER.md](QUERYBUILDER.md) for full details.
+
+```go
+import jonecfg "myapp/jone"
+
+// Single row insert with map
+result, err := jonecfg.DB.Insert(map[string]any{
+    "name":  "John",
+    "email": "john@example.com",
+}).Into("users")
+
+// Multi-row insert
+result, err := jonecfg.DB.Insert([]map[string]any{
+    {"name": "John", "email": "john@example.com"},
+    {"name": "Jane", "email": "jane@example.com"},
+}).Into("users")
+
+// Struct insert (uses db tags or snake_case field names)
+type User struct {
+    Name  string `db:"name"`
+    Email string `db:"email"`
+}
+result, err := jonecfg.DB.Insert(User{Name: "John", Email: "john@example.com"}).Into("users")
+
+// Raw SQL expressions
+result, err := jonecfg.DB.Insert(map[string]any{
+    "name":       "John",
+    "created_at": jone.Fn.Now(), // CURRENT_TIMESTAMP
+}).Into("users")
+
+// Skip conflicting rows (ON CONFLICT DO NOTHING)
+result, err := jonecfg.DB.Insert(map[string]any{
+    "email": "john@example.com",
+    "name":  "John",
+}).OnConflict().Ignore().Into("users")
 ```
 
 ## 📝 Migration Example

--- a/cmd/jone/templates/jonefile.go
+++ b/cmd/jone/templates/jonefile.go
@@ -54,6 +54,8 @@ var Config = jone.Config{
 		TableName: "jone_migrations",
 	},
 }
+
+var DB = jone.New(&Config)
 `
 
 // JoneFile is the parsed template for generating jonefile.go.

--- a/cmd/jone/templates/runner.go
+++ b/cmd/jone/templates/runner.go
@@ -42,7 +42,7 @@ func main() {
 	cfg := &joneconfig.Config
 
 	// Create schema and open database connection
-	s := jone.NewSchema(cfg)
+	s := jone.New(cfg)
 	if !*dryRunFlag {
 		if err := s.Open(); err != nil {
 			fmt.Printf("Failed to connect to database: %v\n", err)

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -9,6 +9,12 @@ import (
 // InsertOptions holds options for INSERT query generation.
 type InsertOptions struct {
 	OnConflictIgnore bool
+	// ConflictColumns are the column names for the ON CONFLICT target.
+	// e.g. ["email"] → ON CONFLICT ("email") DO NOTHING
+	ConflictColumns []string
+	// ConflictRaw is a raw conflict target expression used as-is.
+	// e.g. "(email) WHERE active" → ON CONFLICT (email) WHERE active DO NOTHING
+	ConflictRaw string
 }
 
 // Dialect defines the interface for database-specific SQL generation.
@@ -64,6 +70,15 @@ type Dialect interface {
 
 	// InsertManySQL generates a parameterized INSERT statement for multiple rows.
 	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
+
+	// SelectSQL generates a SELECT statement. WHERE clauses are raw strings (no args).
+	SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string
+
+	// UpdateSQL generates a parameterized UPDATE statement.
+	UpdateSQL(table string, set map[string]any, wheres []string) (string, []any)
+
+	// DeleteSQL generates a DELETE statement. WHERE clauses are raw strings (no args).
+	DeleteSQL(table string, wheres []string) string
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -6,6 +6,11 @@ import (
 	"github.com/Grandbusta/jone/types"
 )
 
+// InsertOptions holds options for INSERT query generation.
+type InsertOptions struct {
+	OnConflictIgnore bool
+}
+
 // Dialect defines the interface for database-specific SQL generation.
 type Dialect interface {
 	// Name returns the dialect name (e.g., "postgresql", "mysql").
@@ -51,6 +56,14 @@ type Dialect interface {
 	// QualifyTable returns a schema-qualified table name.
 	// If schema is empty, returns just the quoted table name.
 	QualifyTable(schema, tableName string) string
+
+	// --- Query Builder Methods ---
+
+	// InsertSQL generates a parameterized INSERT statement for a single row.
+	InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any)
+
+	// InsertManySQL generates a parameterized INSERT statement for multiple rows.
+	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/helpers.go
+++ b/dialect/helpers.go
@@ -1,0 +1,14 @@
+package dialect
+
+import "sort"
+
+// sortedKeys returns the keys of a map sorted alphabetically.
+// This ensures deterministic column ordering in generated SQL.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -183,6 +183,8 @@ func (d *MySQLDialect) mapDataType(col *types.Column) string {
 // formatDefault formats a default value for SQL.
 func (d *MySQLDialect) formatDefault(value any) string {
 	switch v := value.(type) {
+	case types.RawExpr:
+		return v.Expr
 	case string:
 		return fmt.Sprintf("'%s'", v)
 	case bool:
@@ -405,6 +407,77 @@ func (d *MySQLDialect) QualifyTable(schema, tableName string) string {
 		return d.QuoteIdentifier(tableName)
 	}
 	return fmt.Sprintf("%s.%s", d.QuoteIdentifier(schema), d.QuoteIdentifier(tableName))
+}
+
+// --- Query Builder Methods ---
+
+// InsertSQL generates a parameterized INSERT statement for MySQL.
+func (d *MySQLDialect) InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data)
+	cols := make([]string, len(keys))
+	placeholders := make([]string, len(keys))
+	var args []any
+
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+		if raw, ok := data[k].(types.RawExpr); ok {
+			placeholders[i] = raw.Expr
+		} else {
+			placeholders[i] = "?"
+			args = append(args, data[k])
+		}
+	}
+
+	verb := "INSERT INTO"
+	if opts.OnConflictIgnore {
+		verb = "INSERT IGNORE INTO"
+	}
+
+	sql := fmt.Sprintf("%s %s (%s) VALUES (%s);",
+		verb,
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "))
+
+	return sql, args
+}
+
+// InsertManySQL generates a parameterized INSERT statement for multiple rows in MySQL.
+func (d *MySQLDialect) InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data[0])
+	cols := make([]string, len(keys))
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+	}
+
+	var args []any
+	var valueSets []string
+
+	for _, row := range data {
+		placeholders := make([]string, len(keys))
+		for i, k := range keys {
+			if raw, ok := row[k].(types.RawExpr); ok {
+				placeholders[i] = raw.Expr
+			} else {
+				placeholders[i] = "?"
+				args = append(args, row[k])
+			}
+		}
+		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
+	}
+
+	verb := "INSERT INTO"
+	if opts.OnConflictIgnore {
+		verb = "INSERT IGNORE INTO"
+	}
+
+	sql := fmt.Sprintf("%s %s (%s) VALUES %s;",
+		verb,
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(valueSets, ", "))
+
+	return sql, args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -480,6 +480,70 @@ func (d *MySQLDialect) InsertManySQL(table string, data []map[string]any, opts I
 	return sql, args
 }
 
+// SelectSQL generates a SELECT statement for MySQL.
+func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+	cols := "*"
+	if len(columns) > 0 {
+		quoted := make([]string, len(columns))
+		for i, c := range columns {
+			if c == "*" {
+				quoted[i] = c
+			} else {
+				quoted[i] = d.QuoteIdentifier(c)
+			}
+		}
+		cols = strings.Join(quoted, ", ")
+	}
+
+	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	if len(orderBys) > 0 {
+		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+	}
+	if limit != nil {
+		sql += fmt.Sprintf(" LIMIT %d", *limit)
+	}
+	if offset != nil {
+		sql += fmt.Sprintf(" OFFSET %d", *offset)
+	}
+	return sql + ";"
+}
+
+// UpdateSQL generates a parameterized UPDATE statement for MySQL.
+func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+	keys := sortedKeys(set)
+	setClauses := make([]string, len(keys))
+	var args []any
+
+	for i, k := range keys {
+		if raw, ok := set[k].(types.RawExpr); ok {
+			setClauses[i] = fmt.Sprintf("%s = %s", d.QuoteIdentifier(k), raw.Expr)
+		} else {
+			setClauses[i] = fmt.Sprintf("%s = ?", d.QuoteIdentifier(k))
+			args = append(args, set[k])
+		}
+	}
+
+	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";", args
+}
+
+// DeleteSQL generates a DELETE statement for MySQL.
+func (d *MySQLDialect) DeleteSQL(table string, wheres []string) string {
+	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";"
+}
+
 // --- Migration Tracking Methods ---
 
 // CreateMigrationsTableSQL returns SQL to create the migrations tracking table.

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -177,6 +177,8 @@ func (d *PostgresDialect) mapDataType(col *types.Column) string {
 // formatDefault formats a default value for SQL.
 func (d *PostgresDialect) formatDefault(value any) string {
 	switch v := value.(type) {
+	case types.RawExpr:
+		return v.Expr
 	case string:
 		return fmt.Sprintf("'%s'", v)
 	case bool:
@@ -400,6 +402,81 @@ func (d *PostgresDialect) QualifyTable(schema, tableName string) string {
 		return d.QuoteIdentifier(tableName)
 	}
 	return fmt.Sprintf("%s.%s", d.QuoteIdentifier(schema), d.QuoteIdentifier(tableName))
+}
+
+// --- Query Builder Methods ---
+
+// InsertSQL generates a parameterized INSERT statement for PostgreSQL.
+func (d *PostgresDialect) InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data)
+	cols := make([]string, len(keys))
+	placeholders := make([]string, len(keys))
+	var args []any
+	paramIdx := 0
+
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+		if raw, ok := data[k].(types.RawExpr); ok {
+			placeholders[i] = raw.Expr
+		} else {
+			paramIdx++
+			placeholders[i] = fmt.Sprintf("$%d", paramIdx)
+			args = append(args, data[k])
+		}
+	}
+
+	conflict := ""
+	if opts.OnConflictIgnore {
+		conflict = " ON CONFLICT DO NOTHING"
+	}
+
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s;",
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+		conflict)
+
+	return sql, args
+}
+
+// InsertManySQL generates a parameterized INSERT statement for multiple rows in PostgreSQL.
+func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data[0])
+	cols := make([]string, len(keys))
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+	}
+
+	var args []any
+	paramIdx := 0
+	var valueSets []string
+
+	for _, row := range data {
+		placeholders := make([]string, len(keys))
+		for i, k := range keys {
+			if raw, ok := row[k].(types.RawExpr); ok {
+				placeholders[i] = raw.Expr
+			} else {
+				paramIdx++
+				placeholders[i] = fmt.Sprintf("$%d", paramIdx)
+				args = append(args, row[k])
+			}
+		}
+		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
+	}
+
+	conflict := ""
+	if opts.OnConflictIgnore {
+		conflict = " ON CONFLICT DO NOTHING"
+	}
+
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s;",
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(valueSets, ", "),
+		conflict)
+
+	return sql, args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -425,10 +425,7 @@ func (d *PostgresDialect) InsertSQL(table string, data map[string]any, opts Inse
 		}
 	}
 
-	conflict := ""
-	if opts.OnConflictIgnore {
-		conflict = " ON CONFLICT DO NOTHING"
-	}
+	conflict := d.buildConflictClause(opts)
 
 	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s;",
 		d.QuoteIdentifier(table),
@@ -465,10 +462,7 @@ func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opt
 		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
 	}
 
-	conflict := ""
-	if opts.OnConflictIgnore {
-		conflict = " ON CONFLICT DO NOTHING"
-	}
+	conflict := d.buildConflictClause(opts)
 
 	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s;",
 		d.QuoteIdentifier(table),
@@ -477,6 +471,90 @@ func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opt
 		conflict)
 
 	return sql, args
+}
+
+// buildConflictClause generates the ON CONFLICT clause for PostgreSQL INSERT statements.
+func (d *PostgresDialect) buildConflictClause(opts InsertOptions) string {
+	if !opts.OnConflictIgnore {
+		return ""
+	}
+	if opts.ConflictRaw != "" {
+		return fmt.Sprintf(" ON CONFLICT %s DO NOTHING", opts.ConflictRaw)
+	}
+	if len(opts.ConflictColumns) > 0 {
+		cols := make([]string, len(opts.ConflictColumns))
+		for i, c := range opts.ConflictColumns {
+			cols[i] = d.QuoteIdentifier(c)
+		}
+		return fmt.Sprintf(" ON CONFLICT (%s) DO NOTHING", strings.Join(cols, ", "))
+	}
+	return " ON CONFLICT DO NOTHING"
+}
+
+// SelectSQL generates a SELECT statement for PostgreSQL.
+func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+	cols := "*"
+	if len(columns) > 0 {
+		quoted := make([]string, len(columns))
+		for i, c := range columns {
+			if c == "*" {
+				quoted[i] = c
+			} else {
+				quoted[i] = d.QuoteIdentifier(c)
+			}
+		}
+		cols = strings.Join(quoted, ", ")
+	}
+
+	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	if len(orderBys) > 0 {
+		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+	}
+	if limit != nil {
+		sql += fmt.Sprintf(" LIMIT %d", *limit)
+	}
+	if offset != nil {
+		sql += fmt.Sprintf(" OFFSET %d", *offset)
+	}
+	return sql + ";"
+}
+
+// UpdateSQL generates a parameterized UPDATE statement for PostgreSQL.
+func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+	keys := sortedKeys(set)
+	setClauses := make([]string, len(keys))
+	var args []any
+	paramIdx := 0
+
+	for i, k := range keys {
+		if raw, ok := set[k].(types.RawExpr); ok {
+			setClauses[i] = fmt.Sprintf("%s = %s", d.QuoteIdentifier(k), raw.Expr)
+		} else {
+			paramIdx++
+			setClauses[i] = fmt.Sprintf("%s = $%d", d.QuoteIdentifier(k), paramIdx)
+			args = append(args, set[k])
+		}
+	}
+
+	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";", args
+}
+
+// DeleteSQL generates a DELETE statement for PostgreSQL.
+func (d *PostgresDialect) DeleteSQL(table string, wheres []string) string {
+	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";"
 }
 
 // --- Migration Tracking Methods ---

--- a/jone.go
+++ b/jone.go
@@ -32,9 +32,11 @@ type Column = schema.Column
 // Core types (re-exported from types package)
 type CoreTable = types.Table
 type CoreColumn = types.Column
+// Fn provides SQL function helpers (e.g. jone.Fn.Now()).
+var Fn = types.Fn
 
-// NewSchema creates a new Schema with the given config.
-var NewSchema = schema.New
+// New creates a new database instance with the given config.
+var New = schema.New
 
 // Migration types (re-exported from migration package)
 type Registration = migration.Registration

--- a/jone.go
+++ b/jone.go
@@ -26,6 +26,7 @@ type Migrations = config.Migrations
 
 // Schema types (re-exported from schema package)
 type Schema = schema.Schema
+type TxSchema = schema.TxSchema
 type Table = schema.Table
 type Column = schema.Column
 
@@ -34,6 +35,15 @@ type CoreTable = types.Table
 type CoreColumn = types.Column
 // Fn provides SQL function helpers (e.g. jone.Fn.Now()).
 var Fn = types.Fn
+
+// Raw wraps a string as a raw SQL expression, bypassing parameterization.
+// Use for SQL functions, expressions, or conflict targets:
+//
+//	jone.Raw("NOW()")
+//	jone.Raw("(email) WHERE active")
+func Raw(expr string) types.RawExpr {
+	return types.RawExpr{Expr: expr}
+}
 
 // New creates a new database instance with the given config.
 var New = schema.New

--- a/query/builder.go
+++ b/query/builder.go
@@ -59,35 +59,6 @@ func (s *SelectBuilder) ToSQL() (string, []any) {
 	return "", nil
 }
 
-// InsertBuilder builds INSERT queries.
-type InsertBuilder struct {
-	table   string
-	columns []string
-	values  []any
-}
-
-// Insert starts building an INSERT query.
-func Insert(table string) *InsertBuilder {
-	return &InsertBuilder{table: table}
-}
-
-// Columns sets the columns to insert into.
-func (i *InsertBuilder) Columns(columns ...string) *InsertBuilder {
-	i.columns = columns
-	return i
-}
-
-// Values sets the values to insert.
-func (i *InsertBuilder) Values(values ...any) *InsertBuilder {
-	i.values = values
-	return i
-}
-
-// ToSQL generates the INSERT SQL. (stub implementation)
-func (i *InsertBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
-}
 
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {

--- a/query/builder.go
+++ b/query/builder.go
@@ -1,6 +1,12 @@
 // Package query provides query building for DML operations.
-// This is a stub for future implementation.
 package query
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Grandbusta/jone/dialect"
+)
 
 // Builder is the main query builder interface.
 type Builder interface {
@@ -16,6 +22,14 @@ type SelectBuilder struct {
 	orderBy []string
 	limit   *int
 	offset  *int
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewSelectBuilder creates a dialect-aware SelectBuilder (used by Schema).
+func NewSelectBuilder(columns []string, d dialect.Dialect, execer Execer, err error) *SelectBuilder {
+	return &SelectBuilder{columns: columns, dialect: d, execer: execer, err: err}
 }
 
 // Select starts building a SELECT query.
@@ -53,18 +67,42 @@ func (s *SelectBuilder) Offset(n int) *SelectBuilder {
 	return s
 }
 
-// ToSQL generates the SELECT SQL. (stub implementation)
+// ToSQL generates the SELECT SQL.
 func (s *SelectBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if s.dialect == nil {
+		return "", nil
+	}
+	return s.dialect.SelectSQL(s.table, s.columns, s.where, s.orderBy, s.limit, s.offset), nil
 }
 
+// Exec executes the SELECT query and returns the result rows.
+func (s *SelectBuilder) Exec() (*sql.Rows, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	if s.table == "" {
+		return nil, fmt.Errorf("no table specified: call From() before Exec()")
+	}
+	sqlStr, args := s.ToSQL()
+	return s.execer.Query(sqlStr, args...)
+}
 
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {
-	table string
-	set   map[string]any
-	where []string
+	table   string
+	set     map[string]any
+	where   []string
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewUpdateBuilder creates a dialect-aware UpdateBuilder (used by Schema).
+func NewUpdateBuilder(table string, d dialect.Dialect, execer Execer, err error) *UpdateBuilder {
+	return &UpdateBuilder{table: table, set: make(map[string]any), dialect: d, execer: execer, err: err}
 }
 
 // Update starts building an UPDATE query.
@@ -78,22 +116,47 @@ func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
 	return u
 }
 
-// Where adds a WHERE condition.
+// Where adds a WHERE condition (raw string).
 func (u *UpdateBuilder) Where(condition string) *UpdateBuilder {
 	u.where = append(u.where, condition)
 	return u
 }
 
-// ToSQL generates the UPDATE SQL. (stub implementation)
+// ToSQL generates the UPDATE SQL.
 func (u *UpdateBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if u.dialect == nil {
+		return "", nil
+	}
+	return u.dialect.UpdateSQL(u.table, u.set, u.where)
+}
+
+// Exec executes the UPDATE query and returns the result.
+func (u *UpdateBuilder) Exec() (sql.Result, error) {
+	if u.err != nil {
+		return nil, u.err
+	}
+	if u.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	if len(u.set) == 0 {
+		return nil, fmt.Errorf("no values to update: call Set() before Exec()")
+	}
+	sqlStr, args := u.ToSQL()
+	return u.execer.Exec(sqlStr, args...)
 }
 
 // DeleteBuilder builds DELETE queries.
 type DeleteBuilder struct {
-	table string
-	where []string
+	table   string
+	where   []string
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewDeleteBuilder creates a dialect-aware DeleteBuilder (used by Schema).
+func NewDeleteBuilder(table string, d dialect.Dialect, execer Execer, err error) *DeleteBuilder {
+	return &DeleteBuilder{table: table, dialect: d, execer: execer, err: err}
 }
 
 // Delete starts building a DELETE query.
@@ -101,14 +164,28 @@ func Delete(table string) *DeleteBuilder {
 	return &DeleteBuilder{table: table}
 }
 
-// Where adds a WHERE condition.
+// Where adds a WHERE condition (raw string).
 func (d *DeleteBuilder) Where(condition string) *DeleteBuilder {
 	d.where = append(d.where, condition)
 	return d
 }
 
-// ToSQL generates the DELETE SQL. (stub implementation)
+// ToSQL generates the DELETE SQL.
 func (d *DeleteBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if d.dialect == nil {
+		return "", nil
+	}
+	return d.dialect.DeleteSQL(d.table, d.where), nil
+}
+
+// Exec executes the DELETE query and returns the result.
+func (d *DeleteBuilder) Exec() (sql.Result, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	if d.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	sqlStr, _ := d.ToSQL()
+	return d.execer.Exec(sqlStr)
 }

--- a/query/insert.go
+++ b/query/insert.go
@@ -1,0 +1,104 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+// Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
+type Execer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// InsertBuilder builds and executes INSERT queries.
+type InsertBuilder struct {
+	data             any
+	dialect          dialect.Dialect
+	execer           Execer
+	err              error // deferred error (e.g. from lazy connection)
+	onConflictIgnore bool
+}
+
+// ConflictBuilder provides conflict resolution methods for INSERT queries.
+type ConflictBuilder struct {
+	insert *InsertBuilder
+}
+
+// OnConflict starts a conflict resolution clause.
+func (i *InsertBuilder) OnConflict() *ConflictBuilder {
+	return &ConflictBuilder{insert: i}
+}
+
+// Ignore skips rows that conflict with existing data.
+func (c *ConflictBuilder) Ignore() *InsertBuilder {
+	c.insert.onConflictIgnore = true
+	return c.insert
+}
+
+// NewInsertBuilder creates a new InsertBuilder.
+func NewInsertBuilder(data any, d dialect.Dialect, execer Execer, err error) *InsertBuilder {
+	return &InsertBuilder{data: data, dialect: d, execer: execer, err: err}
+}
+
+// Into sets the target table and executes the insert.
+func (i *InsertBuilder) Into(table string) (sql.Result, error) {
+	if i.err != nil {
+		return nil, i.err
+	}
+	if i.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+
+	opts := dialect.InsertOptions{
+		OnConflictIgnore: i.onConflictIgnore,
+	}
+
+	switch data := i.data.(type) {
+	case map[string]any:
+		if len(data) == 0 {
+			return nil, fmt.Errorf("no data to insert")
+		}
+		query, args := i.dialect.InsertSQL(table, data, opts)
+		return i.execer.Exec(query, args...)
+	case []map[string]any:
+		if len(data) == 0 {
+			return nil, fmt.Errorf("no data to insert")
+		}
+		query, args := i.dialect.InsertManySQL(table, data, opts)
+		return i.execer.Exec(query, args...)
+	default:
+		rv := reflect.ValueOf(i.data)
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
+		switch rv.Kind() {
+		case reflect.Struct:
+			m, err := structToMap(i.data)
+			if err != nil {
+				return nil, err
+			}
+			if len(m) == 0 {
+				return nil, fmt.Errorf("no data to insert")
+			}
+			query, args := i.dialect.InsertSQL(table, m, opts)
+			return i.execer.Exec(query, args...)
+		case reflect.Slice:
+			maps, err := structsToMaps(i.data)
+			if err != nil {
+				return nil, err
+			}
+			if len(maps) == 0 {
+				return nil, fmt.Errorf("no data to insert")
+			}
+			query, args := i.dialect.InsertManySQL(table, maps, opts)
+			return i.execer.Exec(query, args...)
+		default:
+			return nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)
+		}
+	}
+}

--- a/query/insert.go
+++ b/query/insert.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/Grandbusta/jone/dialect"
+	"github.com/Grandbusta/jone/types"
 )
 
 // Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
@@ -18,10 +19,13 @@ type Execer interface {
 // InsertBuilder builds and executes INSERT queries.
 type InsertBuilder struct {
 	data             any
+	table            string
 	dialect          dialect.Dialect
 	execer           Execer
 	err              error // deferred error (e.g. from lazy connection)
 	onConflictIgnore bool
+	conflictColumns  []string
+	conflictRaw      string
 }
 
 // ConflictBuilder provides conflict resolution methods for INSERT queries.
@@ -29,8 +33,18 @@ type ConflictBuilder struct {
 	insert *InsertBuilder
 }
 
-// OnConflict starts a conflict resolution clause.
-func (i *InsertBuilder) OnConflict() *ConflictBuilder {
+// OnConflict starts a conflict resolution clause with an optional conflict target.
+// Pass column names to target a specific index: OnConflict("email") or OnConflict("email", "user_id").
+// Pass a jone.Raw() expression for partial indexes: OnConflict(jone.Raw("(email) WHERE active")).
+func (i *InsertBuilder) OnConflict(targets ...any) *ConflictBuilder {
+	for _, t := range targets {
+		switch v := t.(type) {
+		case types.RawExpr:
+			i.conflictRaw = v.Expr
+		case string:
+			i.conflictColumns = append(i.conflictColumns, v)
+		}
+	}
 	return &ConflictBuilder{insert: i}
 }
 
@@ -45,17 +59,28 @@ func NewInsertBuilder(data any, d dialect.Dialect, execer Execer, err error) *In
 	return &InsertBuilder{data: data, dialect: d, execer: execer, err: err}
 }
 
-// Into sets the target table and executes the insert.
-func (i *InsertBuilder) Into(table string) (sql.Result, error) {
+// Into sets the target table for the insert.
+func (i *InsertBuilder) Into(table string) *InsertBuilder {
+	i.table = table
+	return i
+}
+
+// Exec executes the insert and returns the result.
+func (i *InsertBuilder) Exec() (sql.Result, error) {
 	if i.err != nil {
 		return nil, i.err
 	}
 	if i.execer == nil {
 		return nil, fmt.Errorf("no database connection")
 	}
+	if i.table == "" {
+		return nil, fmt.Errorf("no table specified: call Into() before Exec()")
+	}
 
 	opts := dialect.InsertOptions{
 		OnConflictIgnore: i.onConflictIgnore,
+		ConflictColumns:  i.conflictColumns,
+		ConflictRaw:      i.conflictRaw,
 	}
 
 	switch data := i.data.(type) {
@@ -63,13 +88,13 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 		if len(data) == 0 {
 			return nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertSQL(table, data, opts)
+		query, args := i.dialect.InsertSQL(i.table, data, opts)
 		return i.execer.Exec(query, args...)
 	case []map[string]any:
 		if len(data) == 0 {
 			return nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertManySQL(table, data, opts)
+		query, args := i.dialect.InsertManySQL(i.table, data, opts)
 		return i.execer.Exec(query, args...)
 	default:
 		rv := reflect.ValueOf(i.data)
@@ -85,7 +110,7 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 			if len(m) == 0 {
 				return nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertSQL(table, m, opts)
+			query, args := i.dialect.InsertSQL(i.table, m, opts)
 			return i.execer.Exec(query, args...)
 		case reflect.Slice:
 			maps, err := structsToMaps(i.data)
@@ -95,7 +120,7 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 			if len(maps) == 0 {
 				return nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertManySQL(table, maps, opts)
+			query, args := i.dialect.InsertManySQL(i.table, maps, opts)
 			return i.execer.Exec(query, args...)
 		default:
 			return nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)

--- a/query/reflect.go
+++ b/query/reflect.go
@@ -1,0 +1,97 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// toSnakeCase converts PascalCase/camelCase to snake_case.
+// e.g. "CreatedAt" → "created_at", "HTTPServer" → "http_server"
+func toSnakeCase(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				prev := runes[i-1]
+				// Insert underscore before uppercase that follows lowercase,
+				// or before uppercase that starts a new word in a run of capitals.
+				if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+					result.WriteRune('_')
+				}
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// structToMap converts a struct to map[string]any using db tags with snake_case fallback.
+// Skips unexported fields and fields tagged with db:"-".
+func structToMap(v any) (map[string]any, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("structToMap expects a struct, got %T", v)
+	}
+
+	rt := rv.Type()
+	m := make(map[string]any, rt.NumField())
+
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Check db tag
+		tag := field.Tag.Get("db")
+		if tag == "-" {
+			continue
+		}
+
+		// Use tag value or fall back to snake_case
+		colName := tag
+		if colName == "" {
+			colName = toSnakeCase(field.Name)
+		}
+
+		m[colName] = rv.Field(i).Interface()
+	}
+
+	return m, nil
+}
+
+// structsToMaps converts a slice of structs to []map[string]any.
+func structsToMaps(v any) ([]map[string]any, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("structsToMaps expects a slice, got %T", v)
+	}
+
+	if rv.Len() == 0 {
+		return nil, nil
+	}
+
+	maps := make([]map[string]any, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		elem := rv.Index(i).Interface()
+		m, err := structToMap(elem)
+		if err != nil {
+			return nil, err
+		}
+		maps[i] = m
+	}
+	return maps, nil
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -184,6 +184,71 @@ func (s *Schema) Insert(data any) *query.InsertBuilder {
 	return query.NewInsertBuilder(data, s.dialect, s.execer, err)
 }
 
+// Select starts building a SELECT query with the given columns.
+func (s *Schema) Select(columns ...string) *query.SelectBuilder {
+	err := s.ensureOpen()
+	return query.NewSelectBuilder(columns, s.dialect, s.execer, err)
+}
+
+// Update starts building an UPDATE query for the given table.
+func (s *Schema) Update(table string) *query.UpdateBuilder {
+	err := s.ensureOpen()
+	return query.NewUpdateBuilder(table, s.dialect, s.execer, err)
+}
+
+// Delete starts building a DELETE query for the given table.
+func (s *Schema) Delete(table string) *query.DeleteBuilder {
+	err := s.ensureOpen()
+	return query.NewDeleteBuilder(table, s.dialect, s.execer, err)
+}
+
+// Transaction runs fn inside a database transaction.
+// Automatically commits on nil return, rolls back on error.
+func (s *Schema) Transaction(fn func(tx *Schema) error) error {
+	if err := s.ensureOpen(); err != nil {
+		return err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	txSchema := s.WithTx(tx)
+	if err := fn(txSchema); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+// TxSchema is a Schema scoped to an active transaction.
+// Use Commit() or Rollback() to finalize the transaction.
+type TxSchema struct {
+	*Schema
+	tx *sql.Tx
+}
+
+// Commit commits the transaction.
+func (t *TxSchema) Commit() error {
+	return t.tx.Commit()
+}
+
+// Rollback aborts the transaction.
+func (t *TxSchema) Rollback() error {
+	return t.tx.Rollback()
+}
+
+// Begin starts a new transaction and returns a TxSchema for manual commit/rollback control.
+func (s *Schema) Begin() (*TxSchema, error) {
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	return &TxSchema{Schema: s.WithTx(tx), tx: tx}, nil
+}
+
 func (s *Schema) Table(name string, builder func(t *Table)) {
 	t := NewTable(name)
 	t.Schema = s.schema // Set schema context

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/Grandbusta/jone/config"
 	"github.com/Grandbusta/jone/dialect"
+	"github.com/Grandbusta/jone/query"
 )
 
 // Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
@@ -18,11 +20,13 @@ type Execer interface {
 
 // Schema provides methods for database schema operations.
 type Schema struct {
-	dialect dialect.Dialect
-	db      *sql.DB // original connection (for Begin, Close)
-	execer  Execer  // current executor (db or tx)
-	config  *config.Config
-	schema  string // current schema context
+	dialect  dialect.Dialect
+	db       *sql.DB // original connection (for Begin, Close)
+	execer   Execer  // current executor (db or tx)
+	config   *config.Config
+	schema   string // current schema context
+	openOnce sync.Once
+	openErr  error
 }
 
 // fatal logs the error and exits. Used for unrecoverable schema errors during migrations.
@@ -94,10 +98,34 @@ func (s *Schema) SetDB(db *sql.DB) {
 	s.execer = db
 }
 
+// ensureOpen lazily opens the database connection on first use.
+// Safe for concurrent use — only connects once.
+func (s *Schema) ensureOpen() error {
+	s.openOnce.Do(func() {
+		if s.db != nil {
+			return // already opened explicitly via Open()
+		}
+		s.openErr = s.open()
+	})
+	return s.openErr
+}
+
 // Open opens a database connection using the config.
-// It uses the dialect to determine the driver and DSN format, and applies
-// any connection pool settings from the config.
+// Can be called explicitly for eager connection, or left to ensureOpen for lazy connection.
 func (s *Schema) Open() error {
+	var err error
+	s.openOnce.Do(func() {
+		err = s.open()
+		s.openErr = err
+	})
+	if err != nil {
+		return err
+	}
+	return s.openErr
+}
+
+// open is the internal connection logic.
+func (s *Schema) open() error {
 	driver := s.dialect.DriverName()
 	dsn := s.dialect.FormatDSN(s.config.Connection)
 	db, err := sql.Open(driver, dsn)
@@ -147,6 +175,13 @@ func (s *Schema) Raw(sqlStmt string, args ...any) {
 	} else {
 		fmt.Println(sqlStmt)
 	}
+}
+
+// Insert starts building an INSERT query with the given data.
+// Accepts map[string]any for a single row, or []map[string]any for multiple rows.
+func (s *Schema) Insert(data any) *query.InsertBuilder {
+	err := s.ensureOpen()
+	return query.NewInsertBuilder(data, s.dialect, s.execer, err)
 }
 
 func (s *Schema) Table(name string, builder func(t *Table)) {

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,22 @@
 // This package has no internal dependencies to prevent import cycles.
 package types
 
+// RawExpr represents a raw SQL expression that should not be parameterized or quoted.
+type RawExpr struct {
+	Expr string
+}
+
+// Functions provides SQL function helpers.
+type Functions struct{}
+
+// Now returns a raw CURRENT_TIMESTAMP expression.
+func (f *Functions) Now() RawExpr {
+	return RawExpr{Expr: "CURRENT_TIMESTAMP"}
+}
+
+// Fn is the global functions instance for use as jone.Fn.Now(), etc.
+var Fn = &Functions{}
+
 // ActionType represents the type of table alteration action.
 type ActionType string
 


### PR DESCRIPTION
# Changes

#### Unified `Exec()` terminal

All four query builders now use `Exec()` as the single execution method. Previously, `Into("table")` on `InsertBuilder` both set the table and executed the query — it now acts as a setter only, keeping configuration and execution cleanly separated. This also means `ToSQL()` can be called to inspect the generated SQL before execution.

```go
// Before
result, err := db.Insert(data).Into("users")

// After
result, err := db.Insert(data).Into("users").Exec()
```

#### SELECT, UPDATE, DELETE builders

Three new fully implemented builders, each following the same `InsertBuilder` pattern (holds `dialect`, `execer`, `err`; `ToSQL()` delegates to dialect; `Exec()` executes):

- **`SelectBuilder`** — `db.Select(cols...).From(table).Where(raw).OrderBy(col).Limit(n).Offset(n).Exec()` → `(*sql.Rows, error)`
- **`UpdateBuilder`** — `db.Update(table).Set(col, val).Where(raw).Exec()` → `(sql.Result, error)`. SET values are parameterized; WHERE is raw strings.
- **`DeleteBuilder`** — `db.Delete(table).Where(raw).Exec()` → `(sql.Result, error)`

Three new methods added to the `Dialect` interface (`SelectSQL`, `UpdateSQL`, `DeleteSQL`) with full implementations in both `PostgresDialect` and `MySQLDialect`.

#### OnConflict column targeting

`OnConflict()` now accepts an optional conflict target, matching Knex.js behaviour:

```go
.OnConflict()                                   // ON CONFLICT DO NOTHING
.OnConflict("email")                            // ON CONFLICT ("email") DO NOTHING
.OnConflict("email", "tenant_id")              // ON CONFLICT ("email", "tenant_id") DO NOTHING
.OnConflict(jone.Raw("(email) WHERE active"))  // partial index support
```

`InsertOptions` gains `ConflictColumns []string` and `ConflictRaw string`. MySQL is unaffected — it always emits `INSERT IGNORE`.

#### `jone.Raw()`

A new top-level helper that wraps any string as a `types.RawExpr`, bypassing parameterization. Works anywhere a value is accepted — INSERT values, UPDATE SET values, column defaults, and `OnConflict` targets.

```go
jone.Raw("gen_random_uuid()")
jone.Raw("(email) WHERE active")
```

#### Transactions

Two transaction styles added to `Schema`:

**Callback style** — auto commit/rollback, Knex-style:
```go
err := db.Transaction(func(tx *jone.Schema) error {
    _, err := tx.Insert(data).Into("users").Exec()
    return err // nil = commit, error = rollback
})
```

**Manual style** — explicit control via `TxSchema`:
```go
tx, err := db.Begin()
// ...
tx.Rollback() // or tx.Commit()
```

`TxSchema` embeds `*Schema` so all query methods work on it directly. It is re-exported as `jone.TxSchema`.
