### PR TITLE
V0.3.0 - Query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ s.Raw("UPDATE users SET status = $1 WHERE created_at < $2", "legacy", "2020-01-0
 
 ## 🔍 Query Builder
 
-Jone includes a Knex-inspired query builder. The database connection is lazy — it connects automatically on first query. See [QUERYBUILDER.md](QUERYBUILDER.md) for full details.
+Jone includes a fluent query builder. The database connection is lazy — it connects automatically on first query.
 
 ```go
 import jonecfg "myapp/jone"

--- a/README.md
+++ b/README.md
@@ -289,32 +289,55 @@ import jonecfg "myapp/jone"
 result, err := jonecfg.DB.Insert(map[string]any{
     "name":  "John",
     "email": "john@example.com",
-}).Into("users")
+}).Into("users").Exec()
 
 // Multi-row insert
 result, err := jonecfg.DB.Insert([]map[string]any{
     {"name": "John", "email": "john@example.com"},
     {"name": "Jane", "email": "jane@example.com"},
-}).Into("users")
+}).Into("users").Exec()
 
 // Struct insert (uses db tags or snake_case field names)
 type User struct {
     Name  string `db:"name"`
     Email string `db:"email"`
 }
-result, err := jonecfg.DB.Insert(User{Name: "John", Email: "john@example.com"}).Into("users")
+result, err := jonecfg.DB.Insert(User{Name: "John", Email: "john@example.com"}).Into("users").Exec()
 
 // Raw SQL expressions
 result, err := jonecfg.DB.Insert(map[string]any{
     "name":       "John",
     "created_at": jone.Fn.Now(), // CURRENT_TIMESTAMP
-}).Into("users")
+}).Into("users").Exec()
 
 // Skip conflicting rows (ON CONFLICT DO NOTHING)
 result, err := jonecfg.DB.Insert(map[string]any{
     "email": "john@example.com",
     "name":  "John",
-}).OnConflict().Ignore().Into("users")
+}).OnConflict().Ignore().Into("users").Exec()
+
+// SELECT with parameterized WHERE
+rows, err := jonecfg.DB.Select("id", "name").From("users").
+    Where("age", ">", 18).              // (column, operator, value)
+    Where("active", true).              // (column, value) → implied =
+    WhereIn("status", []string{"active", "pending"}).
+    WhereNull("deleted_at").
+    OrderBy("created_at", "desc").
+    Limit(10).
+    Exec()
+
+// First row as a map (sql.ErrNoRows if none)
+row, err := jonecfg.DB.Select("*").From("users").Where("id", 1).First()
+
+// UPDATE — SET and WHERE are both parameterized
+result, err := jonecfg.DB.Update("users").
+    Set("name", "Alice").
+    Set("updated_at", jone.Fn.Now()).
+    Where("id", 1).
+    Exec()
+
+// DELETE
+result, err := jonecfg.DB.Delete("users").Where("active", false).Exec()
 ```
 
 ## 📝 Migration Example

--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ rows, err := jonecfg.DB.Select("id", "name").From("users").
     Where("active", true).              // (column, value) → implied =
     WhereIn("status", []string{"active", "pending"}).
     WhereNull("deleted_at").
+    Where(func(g *jone.WhereGroup) {    // parenthesized group
+        g.Where("role", "admin").OrWhere("verified", true)
+    }).
     OrderBy("created_at", "desc").
     Limit(10).
     Exec()

--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ result, err := jonecfg.DB.Insert(map[string]any{
     "name":  "John",
 }).OnConflict().Ignore().Into("users").Exec()
 
+// Get generated values back (PostgreSQL RETURNING)
+rows, err := jonecfg.DB.Insert(map[string]any{
+    "name": "John",
+}).Into("users").ExecReturning("id")
+id := rows[0]["id"]
+
 // SELECT with parameterized WHERE
 rows, err := jonecfg.DB.Select("id", "name").From("users").
     Where("age", ">", 18).              // (column, operator, value)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jone
 
-A Go database migration tool with a fluent schema builder. Supports PostgreSQL and MySQL.
+A Go database query builder. Supports PostgreSQL and MySQL.
 
 ## 📦 Installation
 
@@ -82,6 +82,8 @@ var Config = jone.Config{
         TableName: "jone_migrations",
     },
 }
+
+var DB = jone.New(&Config)
 ```
 
 **MySQL:**
@@ -106,6 +108,8 @@ var Config = jone.Config{
         TableName: "jone_migrations",
     },
 }
+
+var DB = jone.New(&Config)
 ```
 
 ## 🔗 Connection Pooling
@@ -272,6 +276,45 @@ s.Raw("CREATE INDEX CONCURRENTLY idx_users_email ON users(email)")
 // Data migrations with parameters
 s.Raw("INSERT INTO settings (key, value) VALUES ($1, $2)", "version", "1.0")
 s.Raw("UPDATE users SET status = $1 WHERE created_at < $2", "legacy", "2020-01-01")
+```
+
+## 🔍 Query Builder
+
+Jone includes a Knex-inspired query builder. The database connection is lazy — it connects automatically on first query. See [QUERYBUILDER.md](QUERYBUILDER.md) for full details.
+
+```go
+import jonecfg "myapp/jone"
+
+// Single row insert with map
+result, err := jonecfg.DB.Insert(map[string]any{
+    "name":  "John",
+    "email": "john@example.com",
+}).Into("users")
+
+// Multi-row insert
+result, err := jonecfg.DB.Insert([]map[string]any{
+    {"name": "John", "email": "john@example.com"},
+    {"name": "Jane", "email": "jane@example.com"},
+}).Into("users")
+
+// Struct insert (uses db tags or snake_case field names)
+type User struct {
+    Name  string `db:"name"`
+    Email string `db:"email"`
+}
+result, err := jonecfg.DB.Insert(User{Name: "John", Email: "john@example.com"}).Into("users")
+
+// Raw SQL expressions
+result, err := jonecfg.DB.Insert(map[string]any{
+    "name":       "John",
+    "created_at": jone.Fn.Now(), // CURRENT_TIMESTAMP
+}).Into("users")
+
+// Skip conflicting rows (ON CONFLICT DO NOTHING)
+result, err := jonecfg.DB.Insert(map[string]any{
+    "email": "john@example.com",
+    "name":  "John",
+}).OnConflict().Ignore().Into("users")
 ```
 
 ## 📝 Migration Example

--- a/cmd/jone/cli/version.go
+++ b/cmd/jone/cli/version.go
@@ -8,7 +8,7 @@ import (
 
 // Version is the current version of jone.
 // Update this before each release.
-var Version = "v0.2.0"
+var Version = "v0.3.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/cmd/jone/templates/jonefile.go
+++ b/cmd/jone/templates/jonefile.go
@@ -54,6 +54,8 @@ var Config = jone.Config{
 		TableName: "jone_migrations",
 	},
 }
+
+var DB = jone.New(&Config)
 `
 
 // JoneFile is the parsed template for generating jonefile.go.

--- a/cmd/jone/templates/runner.go
+++ b/cmd/jone/templates/runner.go
@@ -42,7 +42,7 @@ func main() {
 	cfg := &joneconfig.Config
 
 	// Create schema and open database connection
-	s := jone.NewSchema(cfg)
+	s := jone.New(cfg)
 	if !*dryRunFlag {
 		if err := s.Open(); err != nil {
 			fmt.Printf("Failed to connect to database: %v\n", err)

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -9,6 +9,12 @@ import (
 // InsertOptions holds options for INSERT query generation.
 type InsertOptions struct {
 	OnConflictIgnore bool
+	// ConflictColumns are the column names for the ON CONFLICT target.
+	// e.g. ["email"] → ON CONFLICT ("email") DO NOTHING
+	ConflictColumns []string
+	// ConflictRaw is a raw conflict target expression used as-is.
+	// e.g. "(email) WHERE active" → ON CONFLICT (email) WHERE active DO NOTHING
+	ConflictRaw string
 }
 
 // Dialect defines the interface for database-specific SQL generation.
@@ -64,6 +70,15 @@ type Dialect interface {
 
 	// InsertManySQL generates a parameterized INSERT statement for multiple rows.
 	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
+
+	// SelectSQL generates a SELECT statement. WHERE clauses are raw strings (no args).
+	SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string
+
+	// UpdateSQL generates a parameterized UPDATE statement.
+	UpdateSQL(table string, set map[string]any, wheres []string) (string, []any)
+
+	// DeleteSQL generates a DELETE statement. WHERE clauses are raw strings (no args).
+	DeleteSQL(table string, wheres []string) string
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -15,6 +15,9 @@ type InsertOptions struct {
 	// ConflictRaw is a raw conflict target expression used as-is.
 	// e.g. "(email) WHERE active" → ON CONFLICT (email) WHERE active DO NOTHING
 	ConflictRaw string
+	// Returning are column names for a RETURNING clause (dialects that
+	// support it only; ignored otherwise).
+	Returning []string
 }
 
 // Dialect defines the interface for database-specific SQL generation.
@@ -76,10 +79,15 @@ type Dialect interface {
 
 	// UpdateSQL generates a parameterized UPDATE statement.
 	// SET params come first; WHERE params continue the numbering.
-	UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any)
+	// returning columns are appended as a RETURNING clause where supported.
+	UpdateSQL(table string, set map[string]any, wheres []Cond, returning []string) (string, []any)
 
 	// DeleteSQL generates a parameterized DELETE statement.
-	DeleteSQL(table string, wheres []Cond) (string, []any)
+	// returning columns are appended as a RETURNING clause where supported.
+	DeleteSQL(table string, wheres []Cond, returning []string) (string, []any)
+
+	// SupportsReturning reports whether the dialect supports RETURNING clauses.
+	SupportsReturning() bool
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -6,6 +6,11 @@ import (
 	"github.com/Grandbusta/jone/types"
 )
 
+// InsertOptions holds options for INSERT query generation.
+type InsertOptions struct {
+	OnConflictIgnore bool
+}
+
 // Dialect defines the interface for database-specific SQL generation.
 type Dialect interface {
 	// Name returns the dialect name (e.g., "postgresql", "mysql").
@@ -51,6 +56,14 @@ type Dialect interface {
 	// QualifyTable returns a schema-qualified table name.
 	// If schema is empty, returns just the quoted table name.
 	QualifyTable(schema, tableName string) string
+
+	// --- Query Builder Methods ---
+
+	// InsertSQL generates a parameterized INSERT statement for a single row.
+	InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any)
+
+	// InsertManySQL generates a parameterized INSERT statement for multiple rows.
+	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -71,14 +71,15 @@ type Dialect interface {
 	// InsertManySQL generates a parameterized INSERT statement for multiple rows.
 	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
 
-	// SelectSQL generates a SELECT statement. WHERE clauses are raw strings (no args).
-	SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string
+	// SelectSQL generates a parameterized SELECT statement.
+	SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any)
 
 	// UpdateSQL generates a parameterized UPDATE statement.
-	UpdateSQL(table string, set map[string]any, wheres []string) (string, []any)
+	// SET params come first; WHERE params continue the numbering.
+	UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any)
 
-	// DeleteSQL generates a DELETE statement. WHERE clauses are raw strings (no args).
-	DeleteSQL(table string, wheres []string) string
+	// DeleteSQL generates a parameterized DELETE statement.
+	DeleteSQL(table string, wheres []Cond) (string, []any)
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/helpers.go
+++ b/dialect/helpers.go
@@ -1,0 +1,14 @@
+package dialect
+
+import "sort"
+
+// sortedKeys returns the keys of a map sorted alphabetically.
+// This ensures deterministic column ordering in generated SQL.
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/dialect/helpers.go
+++ b/dialect/helpers.go
@@ -1,6 +1,9 @@
 package dialect
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // sortedKeys returns the keys of a map sorted alphabetically.
 // This ensures deterministic column ordering in generated SQL.
@@ -11,4 +14,17 @@ func sortedKeys(m map[string]any) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// returningClause renders a " RETURNING ..." clause with quoted columns,
+// or "" when no columns are given.
+func returningClause(cols []string, quote func(string) string) string {
+	if len(cols) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(cols))
+	for i, c := range cols {
+		quoted[i] = quote(c)
+	}
+	return " RETURNING " + strings.Join(quoted, ", ")
 }

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -519,7 +519,8 @@ func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []Cond, 
 }
 
 // UpdateSQL generates a parameterized UPDATE statement for MySQL.
-func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any) {
+// The returning param is ignored — MySQL has no RETURNING support.
+func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond, returning []string) (string, []any) {
 	keys := sortedKeys(set)
 	setClauses := make([]string, len(keys))
 	var args []any
@@ -544,13 +545,19 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 }
 
 // DeleteSQL generates a parameterized DELETE statement for MySQL.
-func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
+// The returning param is ignored — MySQL has no RETURNING support.
+func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
 	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 	}
 	return sql + ";", args
+}
+
+// SupportsReturning reports that MySQL does not support RETURNING clauses.
+func (d *MySQLDialect) SupportsReturning() bool {
+	return false
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -480,8 +480,13 @@ func (d *MySQLDialect) InsertManySQL(table string, data []map[string]any, opts I
 	return sql, args
 }
 
-// SelectSQL generates a SELECT statement for MySQL.
-func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+// mysqlPlaceholder returns the MySQL placeholder (always "?").
+func mysqlPlaceholder(int) string {
+	return "?"
+}
+
+// SelectSQL generates a parameterized SELECT statement for MySQL.
+func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any) {
 	cols := "*"
 	if len(columns) > 0 {
 		quoted := make([]string, len(columns))
@@ -497,11 +502,14 @@ func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []string
 
 	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
 
+	var args []any
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+		sql += " WHERE " + whereSQL
+		args = whereArgs
 	}
 	if len(orderBys) > 0 {
-		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
 	}
 	if limit != nil {
 		sql += fmt.Sprintf(" LIMIT %d", *limit)
@@ -509,11 +517,11 @@ func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []string
 	if offset != nil {
 		sql += fmt.Sprintf(" OFFSET %d", *offset)
 	}
-	return sql + ";"
+	return sql + ";", args
 }
 
 // UpdateSQL generates a parameterized UPDATE statement for MySQL.
-func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any) {
 	keys := sortedKeys(set)
 	setClauses := make([]string, len(keys))
 	var args []any
@@ -530,18 +538,23 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []stri
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+		sql += " WHERE " + whereSQL
+		args = append(args, whereArgs...)
 	}
 	return sql + ";", args
 }
 
-// DeleteSQL generates a DELETE statement for MySQL.
-func (d *MySQLDialect) DeleteSQL(table string, wheres []string) string {
+// DeleteSQL generates a parameterized DELETE statement for MySQL.
+func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	var args []any
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+		sql += " WHERE " + whereSQL
+		args = whereArgs
 	}
-	return sql + ";"
+	return sql + ";", args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -183,6 +183,8 @@ func (d *MySQLDialect) mapDataType(col *types.Column) string {
 // formatDefault formats a default value for SQL.
 func (d *MySQLDialect) formatDefault(value any) string {
 	switch v := value.(type) {
+	case types.RawExpr:
+		return v.Expr
 	case string:
 		return fmt.Sprintf("'%s'", v)
 	case bool:
@@ -405,6 +407,77 @@ func (d *MySQLDialect) QualifyTable(schema, tableName string) string {
 		return d.QuoteIdentifier(tableName)
 	}
 	return fmt.Sprintf("%s.%s", d.QuoteIdentifier(schema), d.QuoteIdentifier(tableName))
+}
+
+// --- Query Builder Methods ---
+
+// InsertSQL generates a parameterized INSERT statement for MySQL.
+func (d *MySQLDialect) InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data)
+	cols := make([]string, len(keys))
+	placeholders := make([]string, len(keys))
+	var args []any
+
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+		if raw, ok := data[k].(types.RawExpr); ok {
+			placeholders[i] = raw.Expr
+		} else {
+			placeholders[i] = "?"
+			args = append(args, data[k])
+		}
+	}
+
+	verb := "INSERT INTO"
+	if opts.OnConflictIgnore {
+		verb = "INSERT IGNORE INTO"
+	}
+
+	sql := fmt.Sprintf("%s %s (%s) VALUES (%s);",
+		verb,
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "))
+
+	return sql, args
+}
+
+// InsertManySQL generates a parameterized INSERT statement for multiple rows in MySQL.
+func (d *MySQLDialect) InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data[0])
+	cols := make([]string, len(keys))
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+	}
+
+	var args []any
+	var valueSets []string
+
+	for _, row := range data {
+		placeholders := make([]string, len(keys))
+		for i, k := range keys {
+			if raw, ok := row[k].(types.RawExpr); ok {
+				placeholders[i] = raw.Expr
+			} else {
+				placeholders[i] = "?"
+				args = append(args, row[k])
+			}
+		}
+		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
+	}
+
+	verb := "INSERT INTO"
+	if opts.OnConflictIgnore {
+		verb = "INSERT IGNORE INTO"
+	}
+
+	sql := fmt.Sprintf("%s %s (%s) VALUES %s;",
+		verb,
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(valueSets, ", "))
+
+	return sql, args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -502,11 +502,9 @@ func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []Cond, 
 
 	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
 
-	var args []any
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
-		args = whereArgs
 	}
 	if len(orderBys) > 0 {
 		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
@@ -537,8 +535,8 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 		args = append(args, whereArgs...)
 	}
@@ -548,11 +546,9 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 // DeleteSQL generates a parameterized DELETE statement for MySQL.
 func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
-	var args []any
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
-		args = whereArgs
 	}
 	return sql + ";", args
 }

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -480,6 +480,70 @@ func (d *MySQLDialect) InsertManySQL(table string, data []map[string]any, opts I
 	return sql, args
 }
 
+// SelectSQL generates a SELECT statement for MySQL.
+func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+	cols := "*"
+	if len(columns) > 0 {
+		quoted := make([]string, len(columns))
+		for i, c := range columns {
+			if c == "*" {
+				quoted[i] = c
+			} else {
+				quoted[i] = d.QuoteIdentifier(c)
+			}
+		}
+		cols = strings.Join(quoted, ", ")
+	}
+
+	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	if len(orderBys) > 0 {
+		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+	}
+	if limit != nil {
+		sql += fmt.Sprintf(" LIMIT %d", *limit)
+	}
+	if offset != nil {
+		sql += fmt.Sprintf(" OFFSET %d", *offset)
+	}
+	return sql + ";"
+}
+
+// UpdateSQL generates a parameterized UPDATE statement for MySQL.
+func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+	keys := sortedKeys(set)
+	setClauses := make([]string, len(keys))
+	var args []any
+
+	for i, k := range keys {
+		if raw, ok := set[k].(types.RawExpr); ok {
+			setClauses[i] = fmt.Sprintf("%s = %s", d.QuoteIdentifier(k), raw.Expr)
+		} else {
+			setClauses[i] = fmt.Sprintf("%s = ?", d.QuoteIdentifier(k))
+			args = append(args, set[k])
+		}
+	}
+
+	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";", args
+}
+
+// DeleteSQL generates a DELETE statement for MySQL.
+func (d *MySQLDialect) DeleteSQL(table string, wheres []string) string {
+	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";"
+}
+
 // --- Migration Tracking Methods ---
 
 // CreateMigrationsTableSQL returns SQL to create the migrations tracking table.

--- a/dialect/order.go
+++ b/dialect/order.go
@@ -1,0 +1,26 @@
+package dialect
+
+import "strings"
+
+// OrderClause represents a single ORDER BY term built by the query builders.
+type OrderClause struct {
+	Column string // quoted with QuoteIdentifier at compile time
+	Dir    string // "ASC", "DESC", or "" for the database default
+	Raw    string // raw SQL used verbatim; takes precedence over Column
+}
+
+// compileOrderBys renders the ORDER BY clause body (without the "ORDER BY " prefix).
+func compileOrderBys(orders []OrderClause, quote func(string) string) string {
+	parts := make([]string, len(orders))
+	for i, o := range orders {
+		if o.Raw != "" {
+			parts[i] = o.Raw
+			continue
+		}
+		parts[i] = quote(o.Column)
+		if o.Dir != "" {
+			parts[i] += " " + o.Dir
+		}
+	}
+	return strings.Join(parts, ", ")
+}

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -177,6 +177,8 @@ func (d *PostgresDialect) mapDataType(col *types.Column) string {
 // formatDefault formats a default value for SQL.
 func (d *PostgresDialect) formatDefault(value any) string {
 	switch v := value.(type) {
+	case types.RawExpr:
+		return v.Expr
 	case string:
 		return fmt.Sprintf("'%s'", v)
 	case bool:
@@ -400,6 +402,81 @@ func (d *PostgresDialect) QualifyTable(schema, tableName string) string {
 		return d.QuoteIdentifier(tableName)
 	}
 	return fmt.Sprintf("%s.%s", d.QuoteIdentifier(schema), d.QuoteIdentifier(tableName))
+}
+
+// --- Query Builder Methods ---
+
+// InsertSQL generates a parameterized INSERT statement for PostgreSQL.
+func (d *PostgresDialect) InsertSQL(table string, data map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data)
+	cols := make([]string, len(keys))
+	placeholders := make([]string, len(keys))
+	var args []any
+	paramIdx := 0
+
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+		if raw, ok := data[k].(types.RawExpr); ok {
+			placeholders[i] = raw.Expr
+		} else {
+			paramIdx++
+			placeholders[i] = fmt.Sprintf("$%d", paramIdx)
+			args = append(args, data[k])
+		}
+	}
+
+	conflict := ""
+	if opts.OnConflictIgnore {
+		conflict = " ON CONFLICT DO NOTHING"
+	}
+
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s;",
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+		conflict)
+
+	return sql, args
+}
+
+// InsertManySQL generates a parameterized INSERT statement for multiple rows in PostgreSQL.
+func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any) {
+	keys := sortedKeys(data[0])
+	cols := make([]string, len(keys))
+	for i, k := range keys {
+		cols[i] = d.QuoteIdentifier(k)
+	}
+
+	var args []any
+	paramIdx := 0
+	var valueSets []string
+
+	for _, row := range data {
+		placeholders := make([]string, len(keys))
+		for i, k := range keys {
+			if raw, ok := row[k].(types.RawExpr); ok {
+				placeholders[i] = raw.Expr
+			} else {
+				paramIdx++
+				placeholders[i] = fmt.Sprintf("$%d", paramIdx)
+				args = append(args, row[k])
+			}
+		}
+		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
+	}
+
+	conflict := ""
+	if opts.OnConflictIgnore {
+		conflict = " ON CONFLICT DO NOTHING"
+	}
+
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s;",
+		d.QuoteIdentifier(table),
+		strings.Join(cols, ", "),
+		strings.Join(valueSets, ", "),
+		conflict)
+
+	return sql, args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -425,10 +425,7 @@ func (d *PostgresDialect) InsertSQL(table string, data map[string]any, opts Inse
 		}
 	}
 
-	conflict := ""
-	if opts.OnConflictIgnore {
-		conflict = " ON CONFLICT DO NOTHING"
-	}
+	conflict := d.buildConflictClause(opts)
 
 	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s;",
 		d.QuoteIdentifier(table),
@@ -465,10 +462,7 @@ func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opt
 		valueSets = append(valueSets, fmt.Sprintf("(%s)", strings.Join(placeholders, ", ")))
 	}
 
-	conflict := ""
-	if opts.OnConflictIgnore {
-		conflict = " ON CONFLICT DO NOTHING"
-	}
+	conflict := d.buildConflictClause(opts)
 
 	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s;",
 		d.QuoteIdentifier(table),
@@ -477,6 +471,90 @@ func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opt
 		conflict)
 
 	return sql, args
+}
+
+// buildConflictClause generates the ON CONFLICT clause for PostgreSQL INSERT statements.
+func (d *PostgresDialect) buildConflictClause(opts InsertOptions) string {
+	if !opts.OnConflictIgnore {
+		return ""
+	}
+	if opts.ConflictRaw != "" {
+		return fmt.Sprintf(" ON CONFLICT %s DO NOTHING", opts.ConflictRaw)
+	}
+	if len(opts.ConflictColumns) > 0 {
+		cols := make([]string, len(opts.ConflictColumns))
+		for i, c := range opts.ConflictColumns {
+			cols[i] = d.QuoteIdentifier(c)
+		}
+		return fmt.Sprintf(" ON CONFLICT (%s) DO NOTHING", strings.Join(cols, ", "))
+	}
+	return " ON CONFLICT DO NOTHING"
+}
+
+// SelectSQL generates a SELECT statement for PostgreSQL.
+func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+	cols := "*"
+	if len(columns) > 0 {
+		quoted := make([]string, len(columns))
+		for i, c := range columns {
+			if c == "*" {
+				quoted[i] = c
+			} else {
+				quoted[i] = d.QuoteIdentifier(c)
+			}
+		}
+		cols = strings.Join(quoted, ", ")
+	}
+
+	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	if len(orderBys) > 0 {
+		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+	}
+	if limit != nil {
+		sql += fmt.Sprintf(" LIMIT %d", *limit)
+	}
+	if offset != nil {
+		sql += fmt.Sprintf(" OFFSET %d", *offset)
+	}
+	return sql + ";"
+}
+
+// UpdateSQL generates a parameterized UPDATE statement for PostgreSQL.
+func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+	keys := sortedKeys(set)
+	setClauses := make([]string, len(keys))
+	var args []any
+	paramIdx := 0
+
+	for i, k := range keys {
+		if raw, ok := set[k].(types.RawExpr); ok {
+			setClauses[i] = fmt.Sprintf("%s = %s", d.QuoteIdentifier(k), raw.Expr)
+		} else {
+			paramIdx++
+			setClauses[i] = fmt.Sprintf("%s = $%d", d.QuoteIdentifier(k), paramIdx)
+			args = append(args, set[k])
+		}
+	}
+
+	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
+
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";", args
+}
+
+// DeleteSQL generates a DELETE statement for PostgreSQL.
+func (d *PostgresDialect) DeleteSQL(table string, wheres []string) string {
+	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	if len(wheres) > 0 {
+		sql += " WHERE " + strings.Join(wheres, " AND ")
+	}
+	return sql + ";"
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -513,11 +513,9 @@ func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []Con
 
 	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
 
-	var args []any
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
-		args = whereArgs
 	}
 	if len(orderBys) > 0 {
 		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
@@ -551,8 +549,8 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, paramIdx)
+	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, paramIdx)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 		args = append(args, whereArgs...)
 	}
@@ -562,11 +560,9 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 // DeleteSQL generates a parameterized DELETE statement for PostgreSQL.
 func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
-	var args []any
-	if len(wheres) > 0 {
-		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
-		args = whereArgs
 	}
 	return sql + ";", args
 }

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -491,8 +491,13 @@ func (d *PostgresDialect) buildConflictClause(opts InsertOptions) string {
 	return " ON CONFLICT DO NOTHING"
 }
 
-// SelectSQL generates a SELECT statement for PostgreSQL.
-func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []string, orderBys []string, limit *int, offset *int) string {
+// pgPlaceholder returns the 1-based PostgreSQL placeholder for param n.
+func pgPlaceholder(n int) string {
+	return fmt.Sprintf("$%d", n)
+}
+
+// SelectSQL generates a parameterized SELECT statement for PostgreSQL.
+func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any) {
 	cols := "*"
 	if len(columns) > 0 {
 		quoted := make([]string, len(columns))
@@ -508,11 +513,14 @@ func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []str
 
 	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
 
+	var args []any
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+		sql += " WHERE " + whereSQL
+		args = whereArgs
 	}
 	if len(orderBys) > 0 {
-		sql += " ORDER BY " + strings.Join(orderBys, ", ")
+		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
 	}
 	if limit != nil {
 		sql += fmt.Sprintf(" LIMIT %d", *limit)
@@ -520,11 +528,12 @@ func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []str
 	if offset != nil {
 		sql += fmt.Sprintf(" OFFSET %d", *offset)
 	}
-	return sql + ";"
+	return sql + ";", args
 }
 
 // UpdateSQL generates a parameterized UPDATE statement for PostgreSQL.
-func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []string) (string, []any) {
+// WHERE param numbering continues after the SET params.
+func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any) {
 	keys := sortedKeys(set)
 	setClauses := make([]string, len(keys))
 	var args []any
@@ -543,18 +552,23 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []s
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, paramIdx)
+		sql += " WHERE " + whereSQL
+		args = append(args, whereArgs...)
 	}
 	return sql + ";", args
 }
 
-// DeleteSQL generates a DELETE statement for PostgreSQL.
-func (d *PostgresDialect) DeleteSQL(table string, wheres []string) string {
+// DeleteSQL generates a parameterized DELETE statement for PostgreSQL.
+func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
+	var args []any
 	if len(wheres) > 0 {
-		sql += " WHERE " + strings.Join(wheres, " AND ")
+		whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+		sql += " WHERE " + whereSQL
+		args = whereArgs
 	}
-	return sql + ";"
+	return sql + ";", args
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -427,11 +427,12 @@ func (d *PostgresDialect) InsertSQL(table string, data map[string]any, opts Inse
 
 	conflict := d.buildConflictClause(opts)
 
-	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s;",
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)%s%s;",
 		d.QuoteIdentifier(table),
 		strings.Join(cols, ", "),
 		strings.Join(placeholders, ", "),
-		conflict)
+		conflict,
+		returningClause(opts.Returning, d.QuoteIdentifier))
 
 	return sql, args
 }
@@ -464,11 +465,12 @@ func (d *PostgresDialect) InsertManySQL(table string, data []map[string]any, opt
 
 	conflict := d.buildConflictClause(opts)
 
-	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s;",
+	sql := fmt.Sprintf("INSERT INTO %s (%s) VALUES %s%s%s;",
 		d.QuoteIdentifier(table),
 		strings.Join(cols, ", "),
 		strings.Join(valueSets, ", "),
-		conflict)
+		conflict,
+		returningClause(opts.Returning, d.QuoteIdentifier))
 
 	return sql, args
 }
@@ -531,7 +533,7 @@ func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []Con
 
 // UpdateSQL generates a parameterized UPDATE statement for PostgreSQL.
 // WHERE param numbering continues after the SET params.
-func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []Cond) (string, []any) {
+func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []Cond, returning []string) (string, []any) {
 	keys := sortedKeys(set)
 	setClauses := make([]string, len(keys))
 	var args []any
@@ -554,17 +556,24 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 		sql += " WHERE " + whereSQL
 		args = append(args, whereArgs...)
 	}
+	sql += returningClause(returning, d.QuoteIdentifier)
 	return sql + ";", args
 }
 
 // DeleteSQL generates a parameterized DELETE statement for PostgreSQL.
-func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond) (string, []any) {
+func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
 	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 	}
+	sql += returningClause(returning, d.QuoteIdentifier)
 	return sql + ";", args
+}
+
+// SupportsReturning reports that PostgreSQL supports RETURNING clauses.
+func (d *PostgresDialect) SupportsReturning() bool {
+	return true
 }
 
 // --- Migration Tracking Methods ---

--- a/dialect/returning_test.go
+++ b/dialect/returning_test.go
@@ -1,0 +1,86 @@
+package dialect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPostgresReturning(t *testing.T) {
+	pg := &PostgresDialect{}
+
+	t.Run("insert single column", func(t *testing.T) {
+		sql, args := pg.InsertSQL("users", map[string]any{"name": "John"}, InsertOptions{Returning: []string{"id"}})
+		want := `INSERT INTO "users" ("name") VALUES ($1) RETURNING "id";`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if !reflect.DeepEqual(args, []any{"John"}) {
+			t.Errorf("args = %v", args)
+		}
+	})
+
+	t.Run("insert returning after on conflict", func(t *testing.T) {
+		sql, _ := pg.InsertSQL("users", map[string]any{"name": "John"},
+			InsertOptions{OnConflictIgnore: true, Returning: []string{"id", "created_at"}})
+		want := `INSERT INTO "users" ("name") VALUES ($1) ON CONFLICT DO NOTHING RETURNING "id", "created_at";`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("insert many", func(t *testing.T) {
+		sql, _ := pg.InsertManySQL("users",
+			[]map[string]any{{"name": "a"}, {"name": "b"}},
+			InsertOptions{Returning: []string{"id"}})
+		want := `INSERT INTO "users" ("name") VALUES ($1), ($2) RETURNING "id";`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("update with where", func(t *testing.T) {
+		sql, args := pg.UpdateSQL("users", map[string]any{"name": "Alice"},
+			[]Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}},
+			[]string{"id", "updated_at"})
+		want := `UPDATE "users" SET "name" = $1 WHERE "id" = $2 RETURNING "id", "updated_at";`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if !reflect.DeepEqual(args, []any{"Alice", 7}) {
+			t.Errorf("args = %v", args)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		sql, args := pg.DeleteSQL("users",
+			[]Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}},
+			[]string{"id"})
+		want := `DELETE FROM "users" WHERE "id" = $1 RETURNING "id";`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if !reflect.DeepEqual(args, []any{7}) {
+			t.Errorf("args = %v", args)
+		}
+	})
+}
+
+func TestMySQLReturningIgnored(t *testing.T) {
+	my := &MySQLDialect{}
+
+	if my.SupportsReturning() {
+		t.Error("MySQL SupportsReturning() = true, want false")
+	}
+
+	sql, _ := my.UpdateSQL("users", map[string]any{"name": "Alice"}, nil, []string{"id"})
+	want := "UPDATE `users` SET `name` = ?;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q (returning must be ignored)", sql, want)
+	}
+}
+
+func TestPostgresSupportsReturning(t *testing.T) {
+	if !(&PostgresDialect{}).SupportsReturning() {
+		t.Error("Postgres SupportsReturning() = false, want true")
+	}
+}

--- a/dialect/where.go
+++ b/dialect/where.go
@@ -17,6 +17,8 @@ const (
 	CondNull
 	// CondRaw is a raw SQL fragment with ? placeholders bound to Values.
 	CondRaw
+	// CondGroup is a parenthesized sub-group of conditions.
+	CondGroup
 )
 
 // Cond represents a single WHERE condition built by the query builders.
@@ -29,6 +31,7 @@ type Cond struct {
 	Value  any    // CondCmp bound value
 	Values []any  // CondIn values / CondRaw args
 	Raw    string // CondRaw SQL containing ? placeholders
+	Group  []Cond // CondGroup nested conditions, compiled inside parentheses
 }
 
 // compileWheres renders the WHERE clause body (without the "WHERE " prefix)
@@ -38,9 +41,10 @@ type Cond struct {
 // SET args), so placeholder numbering continues from there.
 //
 // Conditions are joined left-to-right with AND/OR per each condition's Or
-// flag, without parenthesization — standard SQL precedence applies.
+// flag. Groups compile inside parentheses; empty groups vanish (an empty
+// result string means no condition survived, and the caller should omit the
+// WHERE clause entirely).
 func compileWheres(conds []Cond, quote func(string) string, placeholder func(int) string, startIdx int) (string, []any) {
-	var sb strings.Builder
 	var args []any
 	paramIdx := startIdx
 
@@ -50,27 +54,22 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 		return placeholder(paramIdx)
 	}
 
-	for i, c := range conds {
-		if i > 0 {
-			if c.Or {
-				sb.WriteString(" OR ")
-			} else {
-				sb.WriteString(" AND ")
-			}
-		}
+	// renderCond returns the SQL fragment for one condition, or "" if it
+	// compiles to nothing (an empty group).
+	var render func(conds []Cond) string
+	var renderCond func(c Cond) string
 
+	renderCond = func(c Cond) string {
 		switch c.Kind {
 		case CondCmp:
-			fmt.Fprintf(&sb, "%s %s %s", quote(c.Column), c.Op, nextPlaceholder(c.Value))
+			return fmt.Sprintf("%s %s %s", quote(c.Column), c.Op, nextPlaceholder(c.Value))
 		case CondIn:
 			if len(c.Values) == 0 {
 				// Empty IN matches nothing; empty NOT IN matches everything.
 				if c.Not {
-					sb.WriteString("1 = 1")
-				} else {
-					sb.WriteString("1 = 0")
+					return "1 = 1"
 				}
-				continue
+				return "1 = 0"
 			}
 			placeholders := make([]string, len(c.Values))
 			for j, v := range c.Values {
@@ -80,16 +79,16 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 			if c.Not {
 				op = "NOT IN"
 			}
-			fmt.Fprintf(&sb, "%s %s (%s)", quote(c.Column), op, strings.Join(placeholders, ", "))
+			return fmt.Sprintf("%s %s (%s)", quote(c.Column), op, strings.Join(placeholders, ", "))
 		case CondNull:
 			if c.Not {
-				sb.WriteString(quote(c.Column) + " IS NOT NULL")
-			} else {
-				sb.WriteString(quote(c.Column) + " IS NULL")
+				return quote(c.Column) + " IS NOT NULL"
 			}
+			return quote(c.Column) + " IS NULL"
 		case CondRaw:
 			// Rewrite each ? to the dialect placeholder, binding Values in order.
 			// Every ? is treated as a placeholder, including inside string literals.
+			var sb strings.Builder
 			valIdx := 0
 			for _, r := range c.Raw {
 				if r == '?' && valIdx < len(c.Values) {
@@ -99,8 +98,37 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 					sb.WriteRune(r)
 				}
 			}
+			return sb.String()
+		case CondGroup:
+			body := render(c.Group)
+			if body == "" {
+				return ""
+			}
+			return "(" + body + ")"
 		}
+		return ""
 	}
 
-	return sb.String(), args
+	render = func(conds []Cond) string {
+		var sb strings.Builder
+		wrote := false
+		for _, c := range conds {
+			frag := renderCond(c)
+			if frag == "" {
+				continue
+			}
+			if wrote {
+				if c.Or {
+					sb.WriteString(" OR ")
+				} else {
+					sb.WriteString(" AND ")
+				}
+			}
+			sb.WriteString(frag)
+			wrote = true
+		}
+		return sb.String()
+	}
+
+	return render(conds), args
 }

--- a/dialect/where.go
+++ b/dialect/where.go
@@ -1,0 +1,106 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CondKind identifies the type of a WHERE condition.
+type CondKind int
+
+const (
+	// CondCmp is a comparison: Column Op Value (e.g. "age" > $1).
+	CondCmp CondKind = iota
+	// CondIn is an IN clause: Column IN (Values...). Not flips it to NOT IN.
+	CondIn
+	// CondNull is an IS NULL check. Not flips it to IS NOT NULL.
+	CondNull
+	// CondRaw is a raw SQL fragment with ? placeholders bound to Values.
+	CondRaw
+)
+
+// Cond represents a single WHERE condition built by the query builders.
+type Cond struct {
+	Kind   CondKind
+	Or     bool   // join with OR instead of AND (ignored on the first condition)
+	Not    bool   // CondIn → NOT IN, CondNull → IS NOT NULL
+	Column string // quoted with QuoteIdentifier at compile time
+	Op     string // comparison operator, used verbatim for CondCmp
+	Value  any    // CondCmp bound value
+	Values []any  // CondIn values / CondRaw args
+	Raw    string // CondRaw SQL containing ? placeholders
+}
+
+// compileWheres renders the WHERE clause body (without the "WHERE " prefix)
+// and its bound args. quote quotes identifiers; placeholder(n) returns the
+// 1-based placeholder for param n ("$3" for postgres, "?" for mysql);
+// startIdx is the count of params already emitted by the caller (e.g. UPDATE
+// SET args), so placeholder numbering continues from there.
+//
+// Conditions are joined left-to-right with AND/OR per each condition's Or
+// flag, without parenthesization — standard SQL precedence applies.
+func compileWheres(conds []Cond, quote func(string) string, placeholder func(int) string, startIdx int) (string, []any) {
+	var sb strings.Builder
+	var args []any
+	paramIdx := startIdx
+
+	nextPlaceholder := func(v any) string {
+		paramIdx++
+		args = append(args, v)
+		return placeholder(paramIdx)
+	}
+
+	for i, c := range conds {
+		if i > 0 {
+			if c.Or {
+				sb.WriteString(" OR ")
+			} else {
+				sb.WriteString(" AND ")
+			}
+		}
+
+		switch c.Kind {
+		case CondCmp:
+			fmt.Fprintf(&sb, "%s %s %s", quote(c.Column), c.Op, nextPlaceholder(c.Value))
+		case CondIn:
+			if len(c.Values) == 0 {
+				// Empty IN matches nothing; empty NOT IN matches everything.
+				if c.Not {
+					sb.WriteString("1 = 1")
+				} else {
+					sb.WriteString("1 = 0")
+				}
+				continue
+			}
+			placeholders := make([]string, len(c.Values))
+			for j, v := range c.Values {
+				placeholders[j] = nextPlaceholder(v)
+			}
+			op := "IN"
+			if c.Not {
+				op = "NOT IN"
+			}
+			fmt.Fprintf(&sb, "%s %s (%s)", quote(c.Column), op, strings.Join(placeholders, ", "))
+		case CondNull:
+			if c.Not {
+				sb.WriteString(quote(c.Column) + " IS NOT NULL")
+			} else {
+				sb.WriteString(quote(c.Column) + " IS NULL")
+			}
+		case CondRaw:
+			// Rewrite each ? to the dialect placeholder, binding Values in order.
+			// Every ? is treated as a placeholder, including inside string literals.
+			valIdx := 0
+			for _, r := range c.Raw {
+				if r == '?' && valIdx < len(c.Values) {
+					sb.WriteString(nextPlaceholder(c.Values[valIdx]))
+					valIdx++
+				} else {
+					sb.WriteRune(r)
+				}
+			}
+		}
+	}
+
+	return sb.String(), args
+}

--- a/dialect/where_test.go
+++ b/dialect/where_test.go
@@ -1,0 +1,247 @@
+package dialect
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Grandbusta/jone/types"
+)
+
+func TestSelectSQL_Wheres(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "postgres single cmp",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondCmp, Column: "age", Op: ">", Value: 18}},
+			wantSQL:  `SELECT * FROM "users" WHERE "age" > $1;`,
+			wantArgs: []any{18},
+		},
+		{
+			name:     "mysql single cmp",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondCmp, Column: "age", Op: ">", Value: 18}},
+			wantSQL:  "SELECT * FROM `users` WHERE `age` > ?;",
+			wantArgs: []any{18},
+		},
+		{
+			name:    "postgres and-or joining is flat",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+				{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+				{Kind: CondCmp, Or: true, Column: "c", Op: "=", Value: 3},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "a" = $1 AND "b" = $2 OR "c" = $3;`,
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:     "postgres where in",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondIn, Column: "status", Values: []any{"active", "pending"}}},
+			wantSQL:  `SELECT * FROM "users" WHERE "status" IN ($1, $2);`,
+			wantArgs: []any{"active", "pending"},
+		},
+		{
+			name:     "mysql where not in",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondIn, Not: true, Column: "status", Values: []any{"a", "b"}}},
+			wantSQL:  "SELECT * FROM `users` WHERE `status` NOT IN (?, ?);",
+			wantArgs: []any{"a", "b"},
+		},
+		{
+			name:     "empty in matches nothing",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondIn, Column: "status", Values: nil}},
+			wantSQL:  `SELECT * FROM "users" WHERE 1 = 0;`,
+			wantArgs: nil,
+		},
+		{
+			name:     "empty not in matches everything",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondIn, Not: true, Column: "status", Values: nil}},
+			wantSQL:  `SELECT * FROM "users" WHERE 1 = 1;`,
+			wantArgs: nil,
+		},
+		{
+			name:     "null and not null",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondNull, Column: "deleted_at"}, {Kind: CondNull, Not: true, Column: "email"}},
+			wantSQL:  `SELECT * FROM "users" WHERE "deleted_at" IS NULL AND "email" IS NOT NULL;`,
+			wantArgs: nil,
+		},
+		{
+			name:     "postgres raw rebinding",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondRaw, Raw: "lower(email) = ? AND age > ?", Values: []any{"john@x.com", 18}}},
+			wantSQL:  `SELECT * FROM "users" WHERE lower(email) = $1 AND age > $2;`,
+			wantArgs: []any{"john@x.com", 18},
+		},
+		{
+			name:     "mysql raw is identity",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondRaw, Raw: "lower(email) = ?", Values: []any{"john@x.com"}}},
+			wantSQL:  "SELECT * FROM `users` WHERE lower(email) = ?;",
+			wantArgs: []any{"john@x.com"},
+		},
+		{
+			name:     "no wheres",
+			dialect:  pg,
+			wheres:   nil,
+			wantSQL:  `SELECT * FROM "users";`,
+			wantArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL("users", nil, tt.wheres, nil, nil, nil)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestSelectSQL_OrderBy(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name    string
+		dialect Dialect
+		orders  []OrderClause
+		wantSQL string
+	}{
+		{
+			name:    "postgres column with direction",
+			dialect: pg,
+			orders:  []OrderClause{{Column: "created_at", Dir: "DESC"}},
+			wantSQL: `SELECT * FROM "users" ORDER BY "created_at" DESC;`,
+		},
+		{
+			name:    "mysql column quoted",
+			dialect: my,
+			orders:  []OrderClause{{Column: "created_at", Dir: "DESC"}},
+			wantSQL: "SELECT * FROM `users` ORDER BY `created_at` DESC;",
+		},
+		{
+			name:    "no direction uses database default",
+			dialect: pg,
+			orders:  []OrderClause{{Column: "name"}},
+			wantSQL: `SELECT * FROM "users" ORDER BY "name";`,
+		},
+		{
+			name:    "multiple clauses and raw",
+			dialect: pg,
+			orders: []OrderClause{
+				{Column: "age", Dir: "ASC"},
+				{Raw: "lower(name) DESC"},
+			},
+			wantSQL: `SELECT * FROM "users" ORDER BY "age" ASC, lower(name) DESC;`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL("users", nil, nil, tt.orders, nil, nil)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if args != nil {
+				t.Errorf("args = %v, want nil", args)
+			}
+		})
+	}
+}
+
+func TestUpdateSQL_WhereParamContinuation(t *testing.T) {
+	pg := &PostgresDialect{}
+
+	// SET params are numbered first ($1, $2); WHERE params continue ($3).
+	set := map[string]any{"email": "j@x.com", "name": "John"} // sorted: email, name
+	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
+
+	sql, args := pg.UpdateSQL("users", set, wheres)
+	wantSQL := `UPDATE "users" SET "email" = $1, "name" = $2 WHERE "id" = $3;`
+	if sql != wantSQL {
+		t.Errorf("SQL = %q, want %q", sql, wantSQL)
+	}
+	wantArgs := []any{"j@x.com", "John", 7}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("args = %v, want %v", args, wantArgs)
+	}
+}
+
+func TestUpdateSQL_RawExprSetSkipsParam(t *testing.T) {
+	pg := &PostgresDialect{}
+
+	// RawExpr SET values consume no param, so WHERE numbering continues
+	// after only the bound SET params.
+	set := map[string]any{
+		"name":       "John",
+		"updated_at": types.RawExpr{Expr: "CURRENT_TIMESTAMP"},
+	}
+	wheres := []Cond{{Kind: CondRaw, Raw: "id = ?", Values: []any{7}}}
+
+	sql, args := pg.UpdateSQL("users", set, wheres)
+	wantSQL := `UPDATE "users" SET "name" = $1, "updated_at" = CURRENT_TIMESTAMP WHERE id = $2;`
+	if sql != wantSQL {
+		t.Errorf("SQL = %q, want %q", sql, wantSQL)
+	}
+	wantArgs := []any{"John", 7}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("args = %v, want %v", args, wantArgs)
+	}
+}
+
+func TestUpdateSQL_MySQLWhereArgsOrdered(t *testing.T) {
+	my := &MySQLDialect{}
+
+	set := map[string]any{"name": "John"}
+	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
+
+	sql, args := my.UpdateSQL("users", set, wheres)
+	wantSQL := "UPDATE `users` SET `name` = ? WHERE `id` = ?;"
+	if sql != wantSQL {
+		t.Errorf("SQL = %q, want %q", sql, wantSQL)
+	}
+	wantArgs := []any{"John", 7}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("args = %v, want %v", args, wantArgs)
+	}
+}
+
+func TestDeleteSQL_ReturnsArgs(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
+
+	sql, args := pg.DeleteSQL("users", wheres)
+	if want := `DELETE FROM "users" WHERE "id" = $1;`; sql != want {
+		t.Errorf("postgres SQL = %q, want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{7}) {
+		t.Errorf("postgres args = %v, want [7]", args)
+	}
+
+	sql, args = my.DeleteSQL("users", wheres)
+	if want := "DELETE FROM `users` WHERE `id` = ?;"; sql != want {
+		t.Errorf("mysql SQL = %q, want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{7}) {
+		t.Errorf("mysql args = %v, want [7]", args)
+	}
+}

--- a/dialect/where_test.go
+++ b/dialect/where_test.go
@@ -245,7 +245,7 @@ func TestUpdateSQL_GroupWithRawAfterSetParams(t *testing.T) {
 		}},
 	}
 
-	sql, args := pg.UpdateSQL("users", set, wheres)
+	sql, args := pg.UpdateSQL("users", set, wheres, nil)
 	wantSQL := `UPDATE "users" SET "name" = $1 WHERE (lower(email) = $2 OR "id" = $3);`
 	if sql != wantSQL {
 		t.Errorf("SQL = %q, want %q", sql, wantSQL)
@@ -259,7 +259,7 @@ func TestUpdateSQL_GroupWithRawAfterSetParams(t *testing.T) {
 func TestUpdateAndDeleteSQL_EmptyGroupOmitsWhere(t *testing.T) {
 	pg := &PostgresDialect{}
 
-	sql, args := pg.UpdateSQL("users", map[string]any{"name": "John"}, []Cond{{Kind: CondGroup}})
+	sql, args := pg.UpdateSQL("users", map[string]any{"name": "John"}, []Cond{{Kind: CondGroup}}, nil)
 	if want := `UPDATE "users" SET "name" = $1;`; sql != want {
 		t.Errorf("update SQL = %q, want %q", sql, want)
 	}
@@ -267,7 +267,7 @@ func TestUpdateAndDeleteSQL_EmptyGroupOmitsWhere(t *testing.T) {
 		t.Errorf("update args = %v, want [John]", args)
 	}
 
-	sql, args = pg.DeleteSQL("users", []Cond{{Kind: CondGroup}})
+	sql, args = pg.DeleteSQL("users", []Cond{{Kind: CondGroup}}, nil)
 	if want := `DELETE FROM "users";`; sql != want {
 		t.Errorf("delete SQL = %q, want %q", sql, want)
 	}
@@ -335,7 +335,7 @@ func TestUpdateSQL_WhereParamContinuation(t *testing.T) {
 	set := map[string]any{"email": "j@x.com", "name": "John"} // sorted: email, name
 	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
 
-	sql, args := pg.UpdateSQL("users", set, wheres)
+	sql, args := pg.UpdateSQL("users", set, wheres, nil)
 	wantSQL := `UPDATE "users" SET "email" = $1, "name" = $2 WHERE "id" = $3;`
 	if sql != wantSQL {
 		t.Errorf("SQL = %q, want %q", sql, wantSQL)
@@ -357,7 +357,7 @@ func TestUpdateSQL_RawExprSetSkipsParam(t *testing.T) {
 	}
 	wheres := []Cond{{Kind: CondRaw, Raw: "id = ?", Values: []any{7}}}
 
-	sql, args := pg.UpdateSQL("users", set, wheres)
+	sql, args := pg.UpdateSQL("users", set, wheres, nil)
 	wantSQL := `UPDATE "users" SET "name" = $1, "updated_at" = CURRENT_TIMESTAMP WHERE id = $2;`
 	if sql != wantSQL {
 		t.Errorf("SQL = %q, want %q", sql, wantSQL)
@@ -374,7 +374,7 @@ func TestUpdateSQL_MySQLWhereArgsOrdered(t *testing.T) {
 	set := map[string]any{"name": "John"}
 	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
 
-	sql, args := my.UpdateSQL("users", set, wheres)
+	sql, args := my.UpdateSQL("users", set, wheres, nil)
 	wantSQL := "UPDATE `users` SET `name` = ? WHERE `id` = ?;"
 	if sql != wantSQL {
 		t.Errorf("SQL = %q, want %q", sql, wantSQL)
@@ -391,7 +391,7 @@ func TestDeleteSQL_ReturnsArgs(t *testing.T) {
 
 	wheres := []Cond{{Kind: CondCmp, Column: "id", Op: "=", Value: 7}}
 
-	sql, args := pg.DeleteSQL("users", wheres)
+	sql, args := pg.DeleteSQL("users", wheres, nil)
 	if want := `DELETE FROM "users" WHERE "id" = $1;`; sql != want {
 		t.Errorf("postgres SQL = %q, want %q", sql, want)
 	}
@@ -399,7 +399,7 @@ func TestDeleteSQL_ReturnsArgs(t *testing.T) {
 		t.Errorf("postgres args = %v, want [7]", args)
 	}
 
-	sql, args = my.DeleteSQL("users", wheres)
+	sql, args = my.DeleteSQL("users", wheres, nil)
 	if want := "DELETE FROM `users` WHERE `id` = ?;"; sql != want {
 		t.Errorf("mysql SQL = %q, want %q", sql, want)
 	}

--- a/dialect/where_test.go
+++ b/dialect/where_test.go
@@ -114,6 +114,168 @@ func TestSelectSQL_Wheres(t *testing.T) {
 	}
 }
 
+func TestSelectSQL_Groups(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:    "cond and group, numbering crosses boundary",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+				{Kind: CondGroup, Group: []Cond{
+					{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+					{Kind: CondCmp, Or: true, Column: "c", Op: "=", Value: 3},
+				}},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "a" = $1 AND ("b" = $2 OR "c" = $3);`,
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:    "mysql group",
+			dialect: my,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+				{Kind: CondGroup, Group: []Cond{
+					{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+					{Kind: CondCmp, Or: true, Column: "c", Op: "=", Value: 3},
+				}},
+			},
+			wantSQL:  "SELECT * FROM `users` WHERE `a` = ? AND (`b` = ? OR `c` = ?);",
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:    "group as first condition",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondGroup, Group: []Cond{
+					{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+					{Kind: CondCmp, Or: true, Column: "b", Op: "=", Value: 2},
+				}},
+				{Kind: CondCmp, Column: "c", Op: "=", Value: 3},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE ("a" = $1 OR "b" = $2) AND "c" = $3;`,
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:    "or-joined group",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+				{Kind: CondGroup, Or: true, Group: []Cond{
+					{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+					{Kind: CondCmp, Column: "c", Op: "=", Value: 3},
+				}},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "a" = $1 OR ("b" = $2 AND "c" = $3);`,
+			wantArgs: []any{1, 2, 3},
+		},
+		{
+			name:    "nested group",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondGroup, Group: []Cond{
+					{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+					{Kind: CondGroup, Or: true, Group: []Cond{
+						{Kind: CondNull, Column: "deleted_at"},
+						{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+					}},
+				}},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE ("a" = $1 OR ("deleted_at" IS NULL AND "b" = $2));`,
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:     "empty group alone omits WHERE entirely",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondGroup}},
+			wantSQL:  `SELECT * FROM "users";`,
+			wantArgs: nil,
+		},
+		{
+			name:    "empty group between conds leaves no doubled connector",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "a", Op: "=", Value: 1},
+				{Kind: CondGroup},
+				{Kind: CondCmp, Column: "b", Op: "=", Value: 2},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "a" = $1 AND "b" = $2;`,
+			wantArgs: []any{1, 2},
+		},
+		{
+			name:    "group containing only empty group vanishes",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondGroup, Group: []Cond{{Kind: CondGroup}}},
+			},
+			wantSQL:  `SELECT * FROM "users";`,
+			wantArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL("users", nil, tt.wheres, nil, nil, nil)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestUpdateSQL_GroupWithRawAfterSetParams(t *testing.T) {
+	pg := &PostgresDialect{}
+
+	set := map[string]any{"name": "John"}
+	wheres := []Cond{
+		{Kind: CondGroup, Group: []Cond{
+			{Kind: CondRaw, Raw: "lower(email) = ?", Values: []any{"j@x.com"}},
+			{Kind: CondCmp, Or: true, Column: "id", Op: "=", Value: 7},
+		}},
+	}
+
+	sql, args := pg.UpdateSQL("users", set, wheres)
+	wantSQL := `UPDATE "users" SET "name" = $1 WHERE (lower(email) = $2 OR "id" = $3);`
+	if sql != wantSQL {
+		t.Errorf("SQL = %q, want %q", sql, wantSQL)
+	}
+	wantArgs := []any{"John", "j@x.com", 7}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("args = %v, want %v", args, wantArgs)
+	}
+}
+
+func TestUpdateAndDeleteSQL_EmptyGroupOmitsWhere(t *testing.T) {
+	pg := &PostgresDialect{}
+
+	sql, args := pg.UpdateSQL("users", map[string]any{"name": "John"}, []Cond{{Kind: CondGroup}})
+	if want := `UPDATE "users" SET "name" = $1;`; sql != want {
+		t.Errorf("update SQL = %q, want %q", sql, want)
+	}
+	if !reflect.DeepEqual(args, []any{"John"}) {
+		t.Errorf("update args = %v, want [John]", args)
+	}
+
+	sql, args = pg.DeleteSQL("users", []Cond{{Kind: CondGroup}})
+	if want := `DELETE FROM "users";`; sql != want {
+		t.Errorf("delete SQL = %q, want %q", sql, want)
+	}
+	if args != nil {
+		t.Errorf("delete args = %v, want nil", args)
+	}
+}
+
 func TestSelectSQL_OrderBy(t *testing.T) {
 	pg := &PostgresDialect{}
 	my := &MySQLDialect{}

--- a/jone.go
+++ b/jone.go
@@ -32,9 +32,11 @@ type Column = schema.Column
 // Core types (re-exported from types package)
 type CoreTable = types.Table
 type CoreColumn = types.Column
+// Fn provides SQL function helpers (e.g. jone.Fn.Now()).
+var Fn = types.Fn
 
-// NewSchema creates a new Schema with the given config.
-var NewSchema = schema.New
+// New creates a new database instance with the given config.
+var New = schema.New
 
 // Migration types (re-exported from migration package)
 type Registration = migration.Registration

--- a/jone.go
+++ b/jone.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Grandbusta/jone/config"
 	"github.com/Grandbusta/jone/dialect"
 	"github.com/Grandbusta/jone/migration"
+	"github.com/Grandbusta/jone/query"
 	"github.com/Grandbusta/jone/schema"
 	"github.com/Grandbusta/jone/types"
 )
@@ -30,9 +31,18 @@ type TxSchema = schema.TxSchema
 type Table = schema.Table
 type Column = schema.Column
 
+// WhereGroup collects conditions for a parenthesized WHERE sub-group
+// (re-exported from query package):
+//
+//	db.Select("*").From("users").Where(func(g *jone.WhereGroup) {
+//	    g.Where("role", "admin").OrWhere("age", ">", 65)
+//	})
+type WhereGroup = query.WhereGroup
+
 // Core types (re-exported from types package)
 type CoreTable = types.Table
 type CoreColumn = types.Column
+
 // Fn provides SQL function helpers (e.g. jone.Fn.Now()).
 var Fn = types.Fn
 

--- a/jone.go
+++ b/jone.go
@@ -26,6 +26,7 @@ type Migrations = config.Migrations
 
 // Schema types (re-exported from schema package)
 type Schema = schema.Schema
+type TxSchema = schema.TxSchema
 type Table = schema.Table
 type Column = schema.Column
 
@@ -34,6 +35,15 @@ type CoreTable = types.Table
 type CoreColumn = types.Column
 // Fn provides SQL function helpers (e.g. jone.Fn.Now()).
 var Fn = types.Fn
+
+// Raw wraps a string as a raw SQL expression, bypassing parameterization.
+// Use for SQL functions, expressions, or conflict targets:
+//
+//	jone.Raw("NOW()")
+//	jone.Raw("(email) WHERE active")
+func Raw(expr string) types.RawExpr {
+	return types.RawExpr{Expr: expr}
+}
 
 // New creates a new database instance with the given config.
 var New = schema.New

--- a/query/builder.go
+++ b/query/builder.go
@@ -4,6 +4,8 @@ package query
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
+	"strings"
 
 	"github.com/Grandbusta/jone/dialect"
 )
@@ -14,12 +16,62 @@ type Builder interface {
 	ToSQL() (string, []any)
 }
 
+// parseWhere builds a comparison condition from the variadic Where/OrWhere forms:
+// (column, value) with an implied "=", or (column, operator, value).
+func parseWhere(or bool, args []any) (dialect.Cond, error) {
+	switch len(args) {
+	case 2:
+		col, ok := args[0].(string)
+		if !ok {
+			return dialect.Cond{}, fmt.Errorf("Where column must be a string, got %T", args[0])
+		}
+		return dialect.Cond{Kind: dialect.CondCmp, Or: or, Column: col, Op: "=", Value: args[1]}, nil
+	case 3:
+		col, ok := args[0].(string)
+		if !ok {
+			return dialect.Cond{}, fmt.Errorf("Where column must be a string, got %T", args[0])
+		}
+		op, ok := args[1].(string)
+		if !ok {
+			return dialect.Cond{}, fmt.Errorf("Where operator must be a string, got %T", args[1])
+		}
+		return dialect.Cond{Kind: dialect.CondCmp, Or: or, Column: col, Op: op, Value: args[2]}, nil
+	default:
+		return dialect.Cond{}, fmt.Errorf("Where expects (column, value) or (column, operator, value), got %d args", len(args))
+	}
+}
+
+// inValues normalizes WhereIn's variadic input: a single slice argument
+// (e.g. []string{"a", "b"}) is expanded element-by-element.
+func inValues(values []any) []any {
+	if len(values) == 1 {
+		rv := reflect.ValueOf(values[0])
+		if rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array {
+			expanded := make([]any, rv.Len())
+			for i := 0; i < rv.Len(); i++ {
+				expanded[i] = rv.Index(i).Interface()
+			}
+			return expanded
+		}
+	}
+	return values
+}
+
+// parseWhereRaw builds a raw condition, validating that the number of ?
+// placeholders matches the number of bound args.
+func parseWhereRaw(raw string, args []any) (dialect.Cond, error) {
+	if n := strings.Count(raw, "?"); n != len(args) {
+		return dialect.Cond{}, fmt.Errorf("WhereRaw has %d placeholders but %d args", n, len(args))
+	}
+	return dialect.Cond{Kind: dialect.CondRaw, Raw: raw, Values: args}, nil
+}
+
 // SelectBuilder builds SELECT queries.
 type SelectBuilder struct {
 	table   string
 	columns []string
-	where   []string
-	orderBy []string
+	where   []dialect.Cond
+	orderBy []dialect.OrderClause
 	limit   *int
 	offset  *int
 	dialect dialect.Dialect
@@ -43,15 +95,100 @@ func (s *SelectBuilder) From(table string) *SelectBuilder {
 	return s
 }
 
-// Where adds a WHERE condition.
-func (s *SelectBuilder) Where(condition string) *SelectBuilder {
-	s.where = append(s.where, condition)
+// setErr records a deferred error without masking an earlier one.
+func (s *SelectBuilder) setErr(err error) {
+	if s.err == nil {
+		s.err = err
+	}
+}
+
+// Where adds a parameterized condition: Where(column, value) for equality,
+// or Where(column, operator, value).
+func (s *SelectBuilder) Where(args ...any) *SelectBuilder {
+	cond, err := parseWhere(false, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
 	return s
 }
 
-// OrderBy adds an ORDER BY clause.
-func (s *SelectBuilder) OrderBy(column string) *SelectBuilder {
-	s.orderBy = append(s.orderBy, column)
+// OrWhere is like Where but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhere(args ...any) *SelectBuilder {
+	cond, err := parseWhere(true, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// WhereIn adds an IN condition. Accepts variadic values or a single slice:
+// WhereIn("status", "active", "pending") or WhereIn("status", []string{...}).
+func (s *SelectBuilder) WhereIn(column string, values ...any) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return s
+}
+
+// WhereNotIn adds a NOT IN condition.
+func (s *SelectBuilder) WhereNotIn(column string, values ...any) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondIn, Not: true, Column: column, Values: inValues(values)})
+	return s
+}
+
+// WhereNull adds an IS NULL condition.
+func (s *SelectBuilder) WhereNull(column string) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
+	return s
+}
+
+// WhereNotNull adds an IS NOT NULL condition.
+func (s *SelectBuilder) WhereNotNull(column string) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return s
+}
+
+// WhereRaw adds a raw SQL condition with ? placeholders bound to args.
+// Every ? is treated as a placeholder, including inside string literals.
+func (s *SelectBuilder) WhereRaw(raw string, args ...any) *SelectBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// OrderBy adds an ORDER BY clause for a column with an optional direction
+// ("asc" or "desc", case-insensitive). Omitting the direction uses the
+// database default (ascending). The column is quoted; for expressions use
+// OrderByRaw.
+func (s *SelectBuilder) OrderBy(column string, direction ...string) *SelectBuilder {
+	clause := dialect.OrderClause{Column: column}
+	switch len(direction) {
+	case 0:
+	case 1:
+		dir := strings.ToUpper(direction[0])
+		if dir != "ASC" && dir != "DESC" {
+			s.setErr(fmt.Errorf(`OrderBy direction must be "asc" or "desc", got %q`, direction[0]))
+			return s
+		}
+		clause.Dir = dir
+	default:
+		s.setErr(fmt.Errorf("OrderBy expects (column) or (column, direction), got %d args", len(direction)+1))
+		return s
+	}
+	s.orderBy = append(s.orderBy, clause)
+	return s
+}
+
+// OrderByRaw adds a raw ORDER BY expression used verbatim,
+// e.g. OrderByRaw("lower(name) DESC").
+func (s *SelectBuilder) OrderByRaw(raw string) *SelectBuilder {
+	s.orderBy = append(s.orderBy, dialect.OrderClause{Raw: raw})
 	return s
 }
 
@@ -72,7 +209,7 @@ func (s *SelectBuilder) ToSQL() (string, []any) {
 	if s.dialect == nil {
 		return "", nil
 	}
-	return s.dialect.SelectSQL(s.table, s.columns, s.where, s.orderBy, s.limit, s.offset), nil
+	return s.dialect.SelectSQL(s.table, s.columns, s.where, s.orderBy, s.limit, s.offset)
 }
 
 // Exec executes the SELECT query and returns the result rows.
@@ -90,11 +227,56 @@ func (s *SelectBuilder) Exec() (*sql.Rows, error) {
 	return s.execer.Query(sqlStr, args...)
 }
 
+// First executes the query with LIMIT 1 and returns the first row as a map.
+// Returns sql.ErrNoRows if no row matches. []byte column values are
+// converted to string.
+func (s *SelectBuilder) First() (map[string]any, error) {
+	one := 1
+	s.limit = &one
+
+	rows, err := s.Exec()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return nil, sql.ErrNoRows
+	}
+
+	vals := make([]any, len(cols))
+	ptrs := make([]any, len(cols))
+	for i := range vals {
+		ptrs[i] = &vals[i]
+	}
+	if err := rows.Scan(ptrs...); err != nil {
+		return nil, err
+	}
+
+	row := make(map[string]any, len(cols))
+	for i, col := range cols {
+		if b, ok := vals[i].([]byte); ok {
+			row[col] = string(b)
+		} else {
+			row[col] = vals[i]
+		}
+	}
+	return row, rows.Err()
+}
+
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {
 	table   string
 	set     map[string]any
-	where   []string
+	where   []dialect.Cond
 	dialect dialect.Dialect
 	execer  Execer
 	err     error
@@ -116,9 +298,68 @@ func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
 	return u
 }
 
-// Where adds a WHERE condition (raw string).
-func (u *UpdateBuilder) Where(condition string) *UpdateBuilder {
-	u.where = append(u.where, condition)
+// setErr records a deferred error without masking an earlier one.
+func (u *UpdateBuilder) setErr(err error) {
+	if u.err == nil {
+		u.err = err
+	}
+}
+
+// Where adds a parameterized condition: Where(column, value) for equality,
+// or Where(column, operator, value).
+func (u *UpdateBuilder) Where(args ...any) *UpdateBuilder {
+	cond, err := parseWhere(false, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// OrWhere is like Where but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhere(args ...any) *UpdateBuilder {
+	cond, err := parseWhere(true, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// WhereIn adds an IN condition. Accepts variadic values or a single slice.
+func (u *UpdateBuilder) WhereIn(column string, values ...any) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return u
+}
+
+// WhereNotIn adds a NOT IN condition.
+func (u *UpdateBuilder) WhereNotIn(column string, values ...any) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondIn, Not: true, Column: column, Values: inValues(values)})
+	return u
+}
+
+// WhereNull adds an IS NULL condition.
+func (u *UpdateBuilder) WhereNull(column string) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
+	return u
+}
+
+// WhereNotNull adds an IS NOT NULL condition.
+func (u *UpdateBuilder) WhereNotNull(column string) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return u
+}
+
+// WhereRaw adds a raw SQL condition with ? placeholders bound to args.
+func (u *UpdateBuilder) WhereRaw(raw string, args ...any) *UpdateBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
 	return u
 }
 
@@ -148,7 +389,7 @@ func (u *UpdateBuilder) Exec() (sql.Result, error) {
 // DeleteBuilder builds DELETE queries.
 type DeleteBuilder struct {
 	table   string
-	where   []string
+	where   []dialect.Cond
 	dialect dialect.Dialect
 	execer  Execer
 	err     error
@@ -164,9 +405,68 @@ func Delete(table string) *DeleteBuilder {
 	return &DeleteBuilder{table: table}
 }
 
-// Where adds a WHERE condition (raw string).
-func (d *DeleteBuilder) Where(condition string) *DeleteBuilder {
-	d.where = append(d.where, condition)
+// setErr records a deferred error without masking an earlier one.
+func (d *DeleteBuilder) setErr(err error) {
+	if d.err == nil {
+		d.err = err
+	}
+}
+
+// Where adds a parameterized condition: Where(column, value) for equality,
+// or Where(column, operator, value).
+func (d *DeleteBuilder) Where(args ...any) *DeleteBuilder {
+	cond, err := parseWhere(false, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// OrWhere is like Where but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhere(args ...any) *DeleteBuilder {
+	cond, err := parseWhere(true, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// WhereIn adds an IN condition. Accepts variadic values or a single slice.
+func (d *DeleteBuilder) WhereIn(column string, values ...any) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return d
+}
+
+// WhereNotIn adds a NOT IN condition.
+func (d *DeleteBuilder) WhereNotIn(column string, values ...any) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondIn, Not: true, Column: column, Values: inValues(values)})
+	return d
+}
+
+// WhereNull adds an IS NULL condition.
+func (d *DeleteBuilder) WhereNull(column string) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
+	return d
+}
+
+// WhereNotNull adds an IS NOT NULL condition.
+func (d *DeleteBuilder) WhereNotNull(column string) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return d
+}
+
+// WhereRaw adds a raw SQL condition with ? placeholders bound to args.
+func (d *DeleteBuilder) WhereRaw(raw string, args ...any) *DeleteBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
 	return d
 }
 
@@ -175,7 +475,7 @@ func (d *DeleteBuilder) ToSQL() (string, []any) {
 	if d.dialect == nil {
 		return "", nil
 	}
-	return d.dialect.DeleteSQL(d.table, d.where), nil
+	return d.dialect.DeleteSQL(d.table, d.where)
 }
 
 // Exec executes the DELETE query and returns the result.
@@ -186,6 +486,6 @@ func (d *DeleteBuilder) Exec() (sql.Result, error) {
 	if d.execer == nil {
 		return nil, fmt.Errorf("no database connection")
 	}
-	sqlStr, _ := d.ToSQL()
-	return d.execer.Exec(sqlStr)
+	sqlStr, args := d.ToSQL()
+	return d.execer.Exec(sqlStr, args...)
 }

--- a/query/builder.go
+++ b/query/builder.go
@@ -16,9 +16,98 @@ type Builder interface {
 	ToSQL() (string, []any)
 }
 
-// parseWhere builds a comparison condition from the variadic Where/OrWhere forms:
-// (column, value) with an implied "=", or (column, operator, value).
+// WhereGroup collects conditions for a parenthesized sub-group, built by
+// passing a func to Where/OrWhere:
+//
+//	q.Where(func(g *query.WhereGroup) {
+//	    g.Where("role", "admin").OrWhere("age", ">", 65)
+//	})
+//
+// The full condition family is available inside, including nested groups.
+type WhereGroup struct {
+	conds []dialect.Cond
+	err   error
+}
+
+// setErr records a deferred error without masking an earlier one.
+func (g *WhereGroup) setErr(err error) {
+	if g.err == nil {
+		g.err = err
+	}
+}
+
+// Where adds a parameterized condition to the group: Where(column, value)
+// for equality, Where(column, operator, value), or Where(func) for a nested group.
+func (g *WhereGroup) Where(args ...any) *WhereGroup {
+	cond, err := parseWhere(false, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// OrWhere is like Where but joins with OR instead of AND.
+func (g *WhereGroup) OrWhere(args ...any) *WhereGroup {
+	cond, err := parseWhere(true, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// WhereIn adds an IN condition. Accepts variadic values or a single slice.
+func (g *WhereGroup) WhereIn(column string, values ...any) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return g
+}
+
+// WhereNotIn adds a NOT IN condition.
+func (g *WhereGroup) WhereNotIn(column string, values ...any) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondIn, Not: true, Column: column, Values: inValues(values)})
+	return g
+}
+
+// WhereNull adds an IS NULL condition.
+func (g *WhereGroup) WhereNull(column string) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Column: column})
+	return g
+}
+
+// WhereNotNull adds an IS NOT NULL condition.
+func (g *WhereGroup) WhereNotNull(column string) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return g
+}
+
+// WhereRaw adds a raw SQL condition with ? placeholders bound to args.
+func (g *WhereGroup) WhereRaw(raw string, args ...any) *WhereGroup {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// parseWhere builds a condition from the variadic Where/OrWhere forms:
+// (column, value) with an implied "=", (column, operator, value), or a
+// single func(*WhereGroup) for a parenthesized sub-group.
 func parseWhere(or bool, args []any) (dialect.Cond, error) {
+	if len(args) == 1 {
+		if fn, ok := args[0].(func(*WhereGroup)); ok {
+			g := &WhereGroup{}
+			fn(g)
+			if g.err != nil {
+				return dialect.Cond{}, g.err
+			}
+			return dialect.Cond{Kind: dialect.CondGroup, Or: or, Group: g.conds}, nil
+		}
+	}
 	switch len(args) {
 	case 2:
 		col, ok := args[0].(string)
@@ -37,7 +126,7 @@ func parseWhere(or bool, args []any) (dialect.Cond, error) {
 		}
 		return dialect.Cond{Kind: dialect.CondCmp, Or: or, Column: col, Op: op, Value: args[2]}, nil
 	default:
-		return dialect.Cond{}, fmt.Errorf("Where expects (column, value) or (column, operator, value), got %d args", len(args))
+		return dialect.Cond{}, fmt.Errorf("Where expects (column, value), (column, operator, value), or (func(*WhereGroup)), got %d args", len(args))
 	}
 }
 

--- a/query/builder.go
+++ b/query/builder.go
@@ -155,6 +155,59 @@ func parseWhereRaw(raw string, args []any) (dialect.Cond, error) {
 	return dialect.Cond{Kind: dialect.CondRaw, Raw: raw, Values: args}, nil
 }
 
+// scanRowMaps drains rows into maps keyed by column name.
+// []byte column values are converted to string.
+func scanRowMaps(rows *sql.Rows) ([]map[string]any, error) {
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []map[string]any
+	for rows.Next() {
+		vals := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		row := make(map[string]any, len(cols))
+		for i, col := range cols {
+			if b, ok := vals[i].([]byte); ok {
+				row[col] = string(b)
+			} else {
+				row[col] = vals[i]
+			}
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+// execReturning runs a RETURNING statement via the execer and scans the
+// returned rows into maps.
+func execReturning(execer Execer, sqlStr string, args []any) ([]map[string]any, error) {
+	rows, err := execer.Query(sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanRowMaps(rows)
+}
+
+// checkReturning validates an ExecReturning call against the dialect.
+func checkReturning(d dialect.Dialect, cols []string) error {
+	if len(cols) == 0 {
+		return fmt.Errorf("ExecReturning requires at least one column")
+	}
+	if !d.SupportsReturning() {
+		return fmt.Errorf("RETURNING is not supported by %s; use Exec() and LastInsertId()", d.Name())
+	}
+	return nil
+}
+
 // SelectBuilder builds SELECT queries.
 type SelectBuilder struct {
 	table   string
@@ -329,36 +382,14 @@ func (s *SelectBuilder) First() (map[string]any, error) {
 	}
 	defer rows.Close()
 
-	cols, err := rows.Columns()
+	maps, err := scanRowMaps(rows)
 	if err != nil {
 		return nil, err
 	}
-
-	if !rows.Next() {
-		if err := rows.Err(); err != nil {
-			return nil, err
-		}
+	if len(maps) == 0 {
 		return nil, sql.ErrNoRows
 	}
-
-	vals := make([]any, len(cols))
-	ptrs := make([]any, len(cols))
-	for i := range vals {
-		ptrs[i] = &vals[i]
-	}
-	if err := rows.Scan(ptrs...); err != nil {
-		return nil, err
-	}
-
-	row := make(map[string]any, len(cols))
-	for i, col := range cols {
-		if b, ok := vals[i].([]byte); ok {
-			row[col] = string(b)
-		} else {
-			row[col] = vals[i]
-		}
-	}
-	return row, rows.Err()
+	return maps[0], nil
 }
 
 // UpdateBuilder builds UPDATE queries.
@@ -457,22 +488,43 @@ func (u *UpdateBuilder) ToSQL() (string, []any) {
 	if u.dialect == nil {
 		return "", nil
 	}
-	return u.dialect.UpdateSQL(u.table, u.set, u.where)
+	return u.dialect.UpdateSQL(u.table, u.set, u.where, nil)
+}
+
+// check validates the builder state before execution.
+func (u *UpdateBuilder) check() error {
+	if u.err != nil {
+		return u.err
+	}
+	if u.execer == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if len(u.set) == 0 {
+		return fmt.Errorf("no values to update: call Set() before Exec()")
+	}
+	return nil
 }
 
 // Exec executes the UPDATE query and returns the result.
 func (u *UpdateBuilder) Exec() (sql.Result, error) {
-	if u.err != nil {
-		return nil, u.err
-	}
-	if u.execer == nil {
-		return nil, fmt.Errorf("no database connection")
-	}
-	if len(u.set) == 0 {
-		return nil, fmt.Errorf("no values to update: call Set() before Exec()")
+	if err := u.check(); err != nil {
+		return nil, err
 	}
 	sqlStr, args := u.ToSQL()
 	return u.execer.Exec(sqlStr, args...)
+}
+
+// ExecReturning executes the UPDATE with a RETURNING clause and returns the
+// affected rows. PostgreSQL only — on MySQL use Exec().
+func (u *UpdateBuilder) ExecReturning(columns ...string) ([]map[string]any, error) {
+	if err := u.check(); err != nil {
+		return nil, err
+	}
+	if err := checkReturning(u.dialect, columns); err != nil {
+		return nil, err
+	}
+	sqlStr, args := u.dialect.UpdateSQL(u.table, u.set, u.where, columns)
+	return execReturning(u.execer, sqlStr, args)
 }
 
 // DeleteBuilder builds DELETE queries.
@@ -564,17 +616,38 @@ func (d *DeleteBuilder) ToSQL() (string, []any) {
 	if d.dialect == nil {
 		return "", nil
 	}
-	return d.dialect.DeleteSQL(d.table, d.where)
+	return d.dialect.DeleteSQL(d.table, d.where, nil)
+}
+
+// check validates the builder state before execution.
+func (d *DeleteBuilder) check() error {
+	if d.err != nil {
+		return d.err
+	}
+	if d.execer == nil {
+		return fmt.Errorf("no database connection")
+	}
+	return nil
 }
 
 // Exec executes the DELETE query and returns the result.
 func (d *DeleteBuilder) Exec() (sql.Result, error) {
-	if d.err != nil {
-		return nil, d.err
-	}
-	if d.execer == nil {
-		return nil, fmt.Errorf("no database connection")
+	if err := d.check(); err != nil {
+		return nil, err
 	}
 	sqlStr, args := d.ToSQL()
 	return d.execer.Exec(sqlStr, args...)
+}
+
+// ExecReturning executes the DELETE with a RETURNING clause and returns the
+// deleted rows. PostgreSQL only — on MySQL use Exec().
+func (d *DeleteBuilder) ExecReturning(columns ...string) ([]map[string]any, error) {
+	if err := d.check(); err != nil {
+		return nil, err
+	}
+	if err := checkReturning(d.dialect, columns); err != nil {
+		return nil, err
+	}
+	sqlStr, args := d.dialect.DeleteSQL(d.table, d.where, columns)
+	return execReturning(d.execer, sqlStr, args)
 }

--- a/query/builder.go
+++ b/query/builder.go
@@ -59,35 +59,6 @@ func (s *SelectBuilder) ToSQL() (string, []any) {
 	return "", nil
 }
 
-// InsertBuilder builds INSERT queries.
-type InsertBuilder struct {
-	table   string
-	columns []string
-	values  []any
-}
-
-// Insert starts building an INSERT query.
-func Insert(table string) *InsertBuilder {
-	return &InsertBuilder{table: table}
-}
-
-// Columns sets the columns to insert into.
-func (i *InsertBuilder) Columns(columns ...string) *InsertBuilder {
-	i.columns = columns
-	return i
-}
-
-// Values sets the values to insert.
-func (i *InsertBuilder) Values(values ...any) *InsertBuilder {
-	i.values = values
-	return i
-}
-
-// ToSQL generates the INSERT SQL. (stub implementation)
-func (i *InsertBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
-}
 
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {

--- a/query/builder.go
+++ b/query/builder.go
@@ -1,6 +1,12 @@
 // Package query provides query building for DML operations.
-// This is a stub for future implementation.
 package query
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/Grandbusta/jone/dialect"
+)
 
 // Builder is the main query builder interface.
 type Builder interface {
@@ -16,6 +22,14 @@ type SelectBuilder struct {
 	orderBy []string
 	limit   *int
 	offset  *int
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewSelectBuilder creates a dialect-aware SelectBuilder (used by Schema).
+func NewSelectBuilder(columns []string, d dialect.Dialect, execer Execer, err error) *SelectBuilder {
+	return &SelectBuilder{columns: columns, dialect: d, execer: execer, err: err}
 }
 
 // Select starts building a SELECT query.
@@ -53,18 +67,42 @@ func (s *SelectBuilder) Offset(n int) *SelectBuilder {
 	return s
 }
 
-// ToSQL generates the SELECT SQL. (stub implementation)
+// ToSQL generates the SELECT SQL.
 func (s *SelectBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if s.dialect == nil {
+		return "", nil
+	}
+	return s.dialect.SelectSQL(s.table, s.columns, s.where, s.orderBy, s.limit, s.offset), nil
 }
 
+// Exec executes the SELECT query and returns the result rows.
+func (s *SelectBuilder) Exec() (*sql.Rows, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	if s.table == "" {
+		return nil, fmt.Errorf("no table specified: call From() before Exec()")
+	}
+	sqlStr, args := s.ToSQL()
+	return s.execer.Query(sqlStr, args...)
+}
 
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {
-	table string
-	set   map[string]any
-	where []string
+	table   string
+	set     map[string]any
+	where   []string
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewUpdateBuilder creates a dialect-aware UpdateBuilder (used by Schema).
+func NewUpdateBuilder(table string, d dialect.Dialect, execer Execer, err error) *UpdateBuilder {
+	return &UpdateBuilder{table: table, set: make(map[string]any), dialect: d, execer: execer, err: err}
 }
 
 // Update starts building an UPDATE query.
@@ -78,22 +116,47 @@ func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
 	return u
 }
 
-// Where adds a WHERE condition.
+// Where adds a WHERE condition (raw string).
 func (u *UpdateBuilder) Where(condition string) *UpdateBuilder {
 	u.where = append(u.where, condition)
 	return u
 }
 
-// ToSQL generates the UPDATE SQL. (stub implementation)
+// ToSQL generates the UPDATE SQL.
 func (u *UpdateBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if u.dialect == nil {
+		return "", nil
+	}
+	return u.dialect.UpdateSQL(u.table, u.set, u.where)
+}
+
+// Exec executes the UPDATE query and returns the result.
+func (u *UpdateBuilder) Exec() (sql.Result, error) {
+	if u.err != nil {
+		return nil, u.err
+	}
+	if u.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	if len(u.set) == 0 {
+		return nil, fmt.Errorf("no values to update: call Set() before Exec()")
+	}
+	sqlStr, args := u.ToSQL()
+	return u.execer.Exec(sqlStr, args...)
 }
 
 // DeleteBuilder builds DELETE queries.
 type DeleteBuilder struct {
-	table string
-	where []string
+	table   string
+	where   []string
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewDeleteBuilder creates a dialect-aware DeleteBuilder (used by Schema).
+func NewDeleteBuilder(table string, d dialect.Dialect, execer Execer, err error) *DeleteBuilder {
+	return &DeleteBuilder{table: table, dialect: d, execer: execer, err: err}
 }
 
 // Delete starts building a DELETE query.
@@ -101,14 +164,28 @@ func Delete(table string) *DeleteBuilder {
 	return &DeleteBuilder{table: table}
 }
 
-// Where adds a WHERE condition.
+// Where adds a WHERE condition (raw string).
 func (d *DeleteBuilder) Where(condition string) *DeleteBuilder {
 	d.where = append(d.where, condition)
 	return d
 }
 
-// ToSQL generates the DELETE SQL. (stub implementation)
+// ToSQL generates the DELETE SQL.
 func (d *DeleteBuilder) ToSQL() (string, []any) {
-	// TODO: Implement full SQL generation
-	return "", nil
+	if d.dialect == nil {
+		return "", nil
+	}
+	return d.dialect.DeleteSQL(d.table, d.where), nil
+}
+
+// Exec executes the DELETE query and returns the result.
+func (d *DeleteBuilder) Exec() (sql.Result, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	if d.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	sqlStr, _ := d.ToSQL()
+	return d.execer.Exec(sqlStr)
 }

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -104,6 +104,85 @@ func TestWhereIn_SliceEqualsVariadic(t *testing.T) {
 	}
 }
 
+func TestWhereGroup_BuildsParenthesizedSQL(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		Where("active", true).
+		Where(func(g *WhereGroup) {
+			g.Where("role", "admin").OrWhere("age", ">", 65)
+		}).
+		ToSQL()
+
+	want := `SELECT * FROM "users" WHERE "active" = $1 AND ("role" = $2 OR "age" > $3);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != true || args[1] != "admin" || args[2] != 65 {
+		t.Errorf("args = %v, want [true admin 65]", args)
+	}
+}
+
+func TestWhereGroup_Nested(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		Where(func(g *WhereGroup) {
+			g.Where("a", 1).
+				OrWhere(func(g2 *WhereGroup) {
+					g2.WhereNull("deleted_at").Where("plan", "pro")
+				})
+		}).
+		ToSQL()
+
+	want := `SELECT * FROM "users" WHERE ("a" = $1 OR ("deleted_at" IS NULL AND "plan" = $2));`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWhereGroup_OrWhereFunc(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewDeleteBuilder("users", pg, nil, nil).
+		Where("a", 1).
+		OrWhere(func(g *WhereGroup) {
+			g.Where("b", 2).Where("c", 3)
+		}).
+		ToSQL()
+
+	want := `DELETE FROM "users" WHERE "a" = $1 OR ("b" = $2 AND "c" = $3);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWhereGroup_ErrorPropagates(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").
+		Where(func(g *WhereGroup) {
+			g.Where("only-one") // bad arity inside the group
+		}).
+		Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected group parse error at Exec, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").
+		Where(func(g *WhereGroup) {
+			g.WhereRaw("a = ?", 1, 2) // mismatch inside the group
+		}).
+		Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected group WhereRaw error at Exec, got %v", err)
+	}
+}
+
 func TestOrderBy_InvalidDirection(t *testing.T) {
 	pg := &dialect.PostgresDialect{}
 

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -1,0 +1,240 @@
+package query
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+// recordingExecer records the last query and args passed to it.
+type recordingExecer struct {
+	query string
+	args  []any
+}
+
+func (r *recordingExecer) Exec(query string, args ...any) (sql.Result, error) {
+	r.query = query
+	r.args = args
+	return nil, nil
+}
+
+func (r *recordingExecer) Query(query string, args ...any) (*sql.Rows, error) {
+	r.query = query
+	r.args = args
+	return nil, nil
+}
+
+func (r *recordingExecer) QueryRow(query string, args ...any) *sql.Row {
+	r.query = query
+	r.args = args
+	return nil
+}
+
+func TestWhere_WrongArity(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Where("only-one").Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Where("a", "b", "c", "d").Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+}
+
+func TestWhere_NonStringColumnOrOp(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Where(1, 2).Exec()
+	if err == nil || !strings.Contains(err.Error(), "column must be a string") {
+		t.Errorf("expected column type error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Where("age", 1, 2).Exec()
+	if err == nil || !strings.Contains(err.Error(), "operator must be a string") {
+		t.Errorf("expected operator type error, got %v", err)
+	}
+}
+
+func TestWhereRaw_ArgCountMismatch(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewDeleteBuilder("users", pg, &recordingExecer{}, nil).
+		WhereRaw("a = ? AND b = ?", 1).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+}
+
+func TestDeferredConnectionErrorWins(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	connErr := errors.New("connection refused")
+
+	_, err := NewSelectBuilder(nil, pg, nil, connErr).
+		From("users").Where("bad-arity").Exec()
+	if err != connErr {
+		t.Errorf("expected connection error to win, got %v", err)
+	}
+}
+
+func TestWhereIn_SliceEqualsVariadic(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sliceSQL, sliceArgs := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").WhereIn("status", []string{"active", "pending"}).ToSQL()
+	variadicSQL, variadicArgs := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").WhereIn("status", "active", "pending").ToSQL()
+
+	if sliceSQL != variadicSQL {
+		t.Errorf("slice form SQL %q != variadic form SQL %q", sliceSQL, variadicSQL)
+	}
+	if len(sliceArgs) != 2 || len(variadicArgs) != 2 {
+		t.Errorf("args = %v and %v, want 2 each", sliceArgs, variadicArgs)
+	}
+}
+
+func TestOrderBy_InvalidDirection(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").OrderBy("id", "sideways").Exec()
+	if err == nil || !strings.Contains(err.Error(), "OrderBy direction") {
+		t.Errorf("expected direction error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").OrderBy("id", "asc", "desc").Exec()
+	if err == nil || !strings.Contains(err.Error(), "OrderBy expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+}
+
+func TestOrderBy_QuotesAndNormalizes(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").OrderBy("created_at", "desc").OrderByRaw("lower(name)").ToSQL()
+	want := `SELECT * FROM "users" ORDER BY "created_at" DESC, lower(name);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestDeleteExec_PassesArgs(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	rec := &recordingExecer{}
+
+	_, err := NewDeleteBuilder("users", pg, rec, nil).Where("id", 7).Exec()
+	if err != nil {
+		t.Fatalf("Exec() error: %v", err)
+	}
+	if rec.query != `DELETE FROM "users" WHERE "id" = $1;` {
+		t.Errorf("query = %q", rec.query)
+	}
+	if len(rec.args) != 1 || rec.args[0] != 7 {
+		t.Errorf("args = %v, want [7]", rec.args)
+	}
+}
+
+// --- First() tests using a minimal in-memory driver ---
+
+// stubDriver serves fixed columns/rows and records the last query.
+type stubDriver struct{}
+
+var (
+	stubColumns   []string
+	stubRows      [][]driver.Value
+	stubLastQuery string
+)
+
+func (stubDriver) Open(string) (driver.Conn, error) { return &stubConn{}, nil }
+
+type stubConn struct{}
+
+func (*stubConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not implemented") }
+func (*stubConn) Close() error                        { return nil }
+func (*stubConn) Begin() (driver.Tx, error)           { return nil, errors.New("not implemented") }
+
+func (*stubConn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	stubLastQuery = query
+	rows := make([][]driver.Value, len(stubRows))
+	copy(rows, stubRows)
+	return &stubResultRows{rows: rows}, nil
+}
+
+type stubResultRows struct {
+	rows [][]driver.Value
+	idx  int
+}
+
+func (*stubResultRows) Columns() []string { return stubColumns }
+func (*stubResultRows) Close() error      { return nil }
+
+func (r *stubResultRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.idx])
+	r.idx++
+	return nil
+}
+
+func init() {
+	sql.Register("jone_stub", stubDriver{})
+}
+
+func TestFirst_ReturnsRowAsMap(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id", "name"}
+	stubRows = [][]driver.Value{{int64(1), []byte("John")}}
+
+	pg := &dialect.PostgresDialect{}
+	row, err := NewSelectBuilder([]string{"*"}, pg, db, nil).
+		From("users").Where("id", 1).First()
+	if err != nil {
+		t.Fatalf("First() error: %v", err)
+	}
+
+	if row["id"] != int64(1) {
+		t.Errorf("id = %v (%T), want int64(1)", row["id"], row["id"])
+	}
+	if row["name"] != "John" {
+		t.Errorf("name = %v (%T), want string \"John\" ([]byte should be converted)", row["name"], row["name"])
+	}
+	if !strings.Contains(stubLastQuery, "LIMIT 1") {
+		t.Errorf("query %q missing LIMIT 1", stubLastQuery)
+	}
+}
+
+func TestFirst_NoRows(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id"}
+	stubRows = nil
+
+	pg := &dialect.PostgresDialect{}
+	_, err = NewSelectBuilder(nil, pg, db, nil).From("users").First()
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("expected sql.ErrNoRows, got %v", err)
+	}
+}

--- a/query/insert.go
+++ b/query/insert.go
@@ -65,37 +65,29 @@ func (i *InsertBuilder) Into(table string) *InsertBuilder {
 	return i
 }
 
-// Exec executes the insert and returns the result.
-func (i *InsertBuilder) Exec() (sql.Result, error) {
-	if i.err != nil {
-		return nil, i.err
-	}
-	if i.execer == nil {
-		return nil, fmt.Errorf("no database connection")
-	}
-	if i.table == "" {
-		return nil, fmt.Errorf("no table specified: call Into() before Exec()")
-	}
-
+// build normalizes the insert data and generates the SQL and args.
+// returning columns are appended as a RETURNING clause where supported.
+func (i *InsertBuilder) build(returning []string) (string, []any, error) {
 	opts := dialect.InsertOptions{
 		OnConflictIgnore: i.onConflictIgnore,
 		ConflictColumns:  i.conflictColumns,
 		ConflictRaw:      i.conflictRaw,
+		Returning:        returning,
 	}
 
 	switch data := i.data.(type) {
 	case map[string]any:
 		if len(data) == 0 {
-			return nil, fmt.Errorf("no data to insert")
+			return "", nil, fmt.Errorf("no data to insert")
 		}
 		query, args := i.dialect.InsertSQL(i.table, data, opts)
-		return i.execer.Exec(query, args...)
+		return query, args, nil
 	case []map[string]any:
 		if len(data) == 0 {
-			return nil, fmt.Errorf("no data to insert")
+			return "", nil, fmt.Errorf("no data to insert")
 		}
 		query, args := i.dialect.InsertManySQL(i.table, data, opts)
-		return i.execer.Exec(query, args...)
+		return query, args, nil
 	default:
 		rv := reflect.ValueOf(i.data)
 		if rv.Kind() == reflect.Ptr {
@@ -105,25 +97,76 @@ func (i *InsertBuilder) Exec() (sql.Result, error) {
 		case reflect.Struct:
 			m, err := structToMap(i.data)
 			if err != nil {
-				return nil, err
+				return "", nil, err
 			}
 			if len(m) == 0 {
-				return nil, fmt.Errorf("no data to insert")
+				return "", nil, fmt.Errorf("no data to insert")
 			}
 			query, args := i.dialect.InsertSQL(i.table, m, opts)
-			return i.execer.Exec(query, args...)
+			return query, args, nil
 		case reflect.Slice:
 			maps, err := structsToMaps(i.data)
 			if err != nil {
-				return nil, err
+				return "", nil, err
 			}
 			if len(maps) == 0 {
-				return nil, fmt.Errorf("no data to insert")
+				return "", nil, fmt.Errorf("no data to insert")
 			}
 			query, args := i.dialect.InsertManySQL(i.table, maps, opts)
-			return i.execer.Exec(query, args...)
+			return query, args, nil
 		default:
-			return nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)
+			return "", nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)
 		}
 	}
+}
+
+// ToSQL generates the INSERT SQL.
+func (i *InsertBuilder) ToSQL() (string, []any) {
+	if i.dialect == nil {
+		return "", nil
+	}
+	query, args, _ := i.build(nil)
+	return query, args
+}
+
+// check validates the builder state before execution.
+func (i *InsertBuilder) check() error {
+	if i.err != nil {
+		return i.err
+	}
+	if i.execer == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if i.table == "" {
+		return fmt.Errorf("no table specified: call Into() before Exec()")
+	}
+	return nil
+}
+
+// Exec executes the insert and returns the result.
+func (i *InsertBuilder) Exec() (sql.Result, error) {
+	if err := i.check(); err != nil {
+		return nil, err
+	}
+	query, args, err := i.build(nil)
+	if err != nil {
+		return nil, err
+	}
+	return i.execer.Exec(query, args...)
+}
+
+// ExecReturning executes the insert with a RETURNING clause and returns the
+// inserted rows. PostgreSQL only — on MySQL use Exec() and LastInsertId().
+func (i *InsertBuilder) ExecReturning(columns ...string) ([]map[string]any, error) {
+	if err := i.check(); err != nil {
+		return nil, err
+	}
+	if err := checkReturning(i.dialect, columns); err != nil {
+		return nil, err
+	}
+	query, args, err := i.build(columns)
+	if err != nil {
+		return nil, err
+	}
+	return execReturning(i.execer, query, args)
 }

--- a/query/insert.go
+++ b/query/insert.go
@@ -1,0 +1,104 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+// Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
+type Execer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+	Query(query string, args ...any) (*sql.Rows, error)
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// InsertBuilder builds and executes INSERT queries.
+type InsertBuilder struct {
+	data             any
+	dialect          dialect.Dialect
+	execer           Execer
+	err              error // deferred error (e.g. from lazy connection)
+	onConflictIgnore bool
+}
+
+// ConflictBuilder provides conflict resolution methods for INSERT queries.
+type ConflictBuilder struct {
+	insert *InsertBuilder
+}
+
+// OnConflict starts a conflict resolution clause.
+func (i *InsertBuilder) OnConflict() *ConflictBuilder {
+	return &ConflictBuilder{insert: i}
+}
+
+// Ignore skips rows that conflict with existing data.
+func (c *ConflictBuilder) Ignore() *InsertBuilder {
+	c.insert.onConflictIgnore = true
+	return c.insert
+}
+
+// NewInsertBuilder creates a new InsertBuilder.
+func NewInsertBuilder(data any, d dialect.Dialect, execer Execer, err error) *InsertBuilder {
+	return &InsertBuilder{data: data, dialect: d, execer: execer, err: err}
+}
+
+// Into sets the target table and executes the insert.
+func (i *InsertBuilder) Into(table string) (sql.Result, error) {
+	if i.err != nil {
+		return nil, i.err
+	}
+	if i.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+
+	opts := dialect.InsertOptions{
+		OnConflictIgnore: i.onConflictIgnore,
+	}
+
+	switch data := i.data.(type) {
+	case map[string]any:
+		if len(data) == 0 {
+			return nil, fmt.Errorf("no data to insert")
+		}
+		query, args := i.dialect.InsertSQL(table, data, opts)
+		return i.execer.Exec(query, args...)
+	case []map[string]any:
+		if len(data) == 0 {
+			return nil, fmt.Errorf("no data to insert")
+		}
+		query, args := i.dialect.InsertManySQL(table, data, opts)
+		return i.execer.Exec(query, args...)
+	default:
+		rv := reflect.ValueOf(i.data)
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
+		switch rv.Kind() {
+		case reflect.Struct:
+			m, err := structToMap(i.data)
+			if err != nil {
+				return nil, err
+			}
+			if len(m) == 0 {
+				return nil, fmt.Errorf("no data to insert")
+			}
+			query, args := i.dialect.InsertSQL(table, m, opts)
+			return i.execer.Exec(query, args...)
+		case reflect.Slice:
+			maps, err := structsToMaps(i.data)
+			if err != nil {
+				return nil, err
+			}
+			if len(maps) == 0 {
+				return nil, fmt.Errorf("no data to insert")
+			}
+			query, args := i.dialect.InsertManySQL(table, maps, opts)
+			return i.execer.Exec(query, args...)
+		default:
+			return nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)
+		}
+	}
+}

--- a/query/insert.go
+++ b/query/insert.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/Grandbusta/jone/dialect"
+	"github.com/Grandbusta/jone/types"
 )
 
 // Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
@@ -18,10 +19,13 @@ type Execer interface {
 // InsertBuilder builds and executes INSERT queries.
 type InsertBuilder struct {
 	data             any
+	table            string
 	dialect          dialect.Dialect
 	execer           Execer
 	err              error // deferred error (e.g. from lazy connection)
 	onConflictIgnore bool
+	conflictColumns  []string
+	conflictRaw      string
 }
 
 // ConflictBuilder provides conflict resolution methods for INSERT queries.
@@ -29,8 +33,18 @@ type ConflictBuilder struct {
 	insert *InsertBuilder
 }
 
-// OnConflict starts a conflict resolution clause.
-func (i *InsertBuilder) OnConflict() *ConflictBuilder {
+// OnConflict starts a conflict resolution clause with an optional conflict target.
+// Pass column names to target a specific index: OnConflict("email") or OnConflict("email", "user_id").
+// Pass a jone.Raw() expression for partial indexes: OnConflict(jone.Raw("(email) WHERE active")).
+func (i *InsertBuilder) OnConflict(targets ...any) *ConflictBuilder {
+	for _, t := range targets {
+		switch v := t.(type) {
+		case types.RawExpr:
+			i.conflictRaw = v.Expr
+		case string:
+			i.conflictColumns = append(i.conflictColumns, v)
+		}
+	}
 	return &ConflictBuilder{insert: i}
 }
 
@@ -45,17 +59,28 @@ func NewInsertBuilder(data any, d dialect.Dialect, execer Execer, err error) *In
 	return &InsertBuilder{data: data, dialect: d, execer: execer, err: err}
 }
 
-// Into sets the target table and executes the insert.
-func (i *InsertBuilder) Into(table string) (sql.Result, error) {
+// Into sets the target table for the insert.
+func (i *InsertBuilder) Into(table string) *InsertBuilder {
+	i.table = table
+	return i
+}
+
+// Exec executes the insert and returns the result.
+func (i *InsertBuilder) Exec() (sql.Result, error) {
 	if i.err != nil {
 		return nil, i.err
 	}
 	if i.execer == nil {
 		return nil, fmt.Errorf("no database connection")
 	}
+	if i.table == "" {
+		return nil, fmt.Errorf("no table specified: call Into() before Exec()")
+	}
 
 	opts := dialect.InsertOptions{
 		OnConflictIgnore: i.onConflictIgnore,
+		ConflictColumns:  i.conflictColumns,
+		ConflictRaw:      i.conflictRaw,
 	}
 
 	switch data := i.data.(type) {
@@ -63,13 +88,13 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 		if len(data) == 0 {
 			return nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertSQL(table, data, opts)
+		query, args := i.dialect.InsertSQL(i.table, data, opts)
 		return i.execer.Exec(query, args...)
 	case []map[string]any:
 		if len(data) == 0 {
 			return nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertManySQL(table, data, opts)
+		query, args := i.dialect.InsertManySQL(i.table, data, opts)
 		return i.execer.Exec(query, args...)
 	default:
 		rv := reflect.ValueOf(i.data)
@@ -85,7 +110,7 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 			if len(m) == 0 {
 				return nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertSQL(table, m, opts)
+			query, args := i.dialect.InsertSQL(i.table, m, opts)
 			return i.execer.Exec(query, args...)
 		case reflect.Slice:
 			maps, err := structsToMaps(i.data)
@@ -95,7 +120,7 @@ func (i *InsertBuilder) Into(table string) (sql.Result, error) {
 			if len(maps) == 0 {
 				return nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertManySQL(table, maps, opts)
+			query, args := i.dialect.InsertManySQL(i.table, maps, opts)
 			return i.execer.Exec(query, args...)
 		default:
 			return nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)

--- a/query/insert_test.go
+++ b/query/insert_test.go
@@ -1,0 +1,152 @@
+package query
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+func TestInsertToSQL(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	t.Run("map", func(t *testing.T) {
+		sql, args := NewInsertBuilder(map[string]any{"email": "j@x.com", "name": "John"}, pg, nil, nil).
+			Into("users").ToSQL()
+		want := `INSERT INTO "users" ("email", "name") VALUES ($1, $2);`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if !reflect.DeepEqual(args, []any{"j@x.com", "John"}) {
+			t.Errorf("args = %v", args)
+		}
+	})
+
+	t.Run("multi-row", func(t *testing.T) {
+		sql, _ := NewInsertBuilder([]map[string]any{{"name": "a"}, {"name": "b"}}, pg, nil, nil).
+			Into("users").ToSQL()
+		want := `INSERT INTO "users" ("name") VALUES ($1), ($2);`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		type user struct {
+			Name  string `db:"name"`
+			Email string `db:"email"`
+		}
+		sql, args := NewInsertBuilder(user{Name: "John", Email: "j@x.com"}, pg, nil, nil).
+			Into("users").ToSQL()
+		want := `INSERT INTO "users" ("email", "name") VALUES ($1, $2);`
+		if sql != want {
+			t.Errorf("SQL = %q, want %q", sql, want)
+		}
+		if !reflect.DeepEqual(args, []any{"j@x.com", "John"}) {
+			t.Errorf("args = %v", args)
+		}
+	})
+
+	t.Run("nil dialect", func(t *testing.T) {
+		sql, args := NewInsertBuilder(map[string]any{"name": "x"}, nil, nil, nil).Into("users").ToSQL()
+		if sql != "" || args != nil {
+			t.Errorf("got (%q, %v), want empty", sql, args)
+		}
+	})
+}
+
+func TestExecReturning_Insert(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id"}
+	stubRows = [][]driver.Value{{int64(42)}}
+
+	pg := &dialect.PostgresDialect{}
+	rows, err := NewInsertBuilder(map[string]any{"name": "John"}, pg, db, nil).
+		Into("users").ExecReturning("id")
+	if err != nil {
+		t.Fatalf("ExecReturning() error: %v", err)
+	}
+
+	if len(rows) != 1 || rows[0]["id"] != int64(42) {
+		t.Errorf("rows = %v, want [{id: 42}]", rows)
+	}
+	if !strings.Contains(stubLastQuery, `RETURNING "id"`) {
+		t.Errorf("query %q missing RETURNING clause", stubLastQuery)
+	}
+}
+
+func TestExecReturning_UpdateAndDelete(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id", "name"}
+	stubRows = [][]driver.Value{{int64(1), []byte("John")}, {int64(2), []byte("Jane")}}
+
+	pg := &dialect.PostgresDialect{}
+
+	rows, err := NewUpdateBuilder("users", pg, db, nil).
+		Set("active", false).Where("age", ">", 90).ExecReturning("id", "name")
+	if err != nil {
+		t.Fatalf("update ExecReturning() error: %v", err)
+	}
+	if len(rows) != 2 || rows[1]["name"] != "Jane" {
+		t.Errorf("rows = %v, want 2 rows with []byte converted to string", rows)
+	}
+	if !strings.Contains(stubLastQuery, `RETURNING "id", "name"`) {
+		t.Errorf("query %q missing RETURNING clause", stubLastQuery)
+	}
+
+	rows, err = NewDeleteBuilder("users", pg, db, nil).
+		Where("id", 1).ExecReturning("id")
+	if err != nil {
+		t.Fatalf("delete ExecReturning() error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("rows = %v, want 2", rows)
+	}
+	if !strings.Contains(stubLastQuery, "DELETE FROM") || !strings.Contains(stubLastQuery, `RETURNING "id"`) {
+		t.Errorf("query %q missing DELETE/RETURNING", stubLastQuery)
+	}
+}
+
+func TestExecReturning_Errors(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	pg := &dialect.PostgresDialect{}
+	my := &dialect.MySQLDialect{}
+
+	// MySQL has no RETURNING support.
+	_, err = NewInsertBuilder(map[string]any{"name": "x"}, my, db, nil).
+		Into("users").ExecReturning("id")
+	if err == nil || !strings.Contains(err.Error(), "not supported by mysql") {
+		t.Errorf("expected mysql unsupported error, got %v", err)
+	}
+
+	// At least one column is required.
+	_, err = NewInsertBuilder(map[string]any{"name": "x"}, pg, db, nil).
+		Into("users").ExecReturning()
+	if err == nil || !strings.Contains(err.Error(), "at least one column") {
+		t.Errorf("expected column-count error, got %v", err)
+	}
+
+	// Update's empty-SET guard still applies.
+	_, err = NewUpdateBuilder("users", pg, db, nil).Where("id", 1).ExecReturning("id")
+	if err == nil || !strings.Contains(err.Error(), "no values to update") {
+		t.Errorf("expected empty-SET error, got %v", err)
+	}
+}

--- a/query/reflect.go
+++ b/query/reflect.go
@@ -1,0 +1,97 @@
+package query
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+// toSnakeCase converts PascalCase/camelCase to snake_case.
+// e.g. "CreatedAt" → "created_at", "HTTPServer" → "http_server"
+func toSnakeCase(s string) string {
+	var result strings.Builder
+	runes := []rune(s)
+	for i, r := range runes {
+		if unicode.IsUpper(r) {
+			if i > 0 {
+				prev := runes[i-1]
+				// Insert underscore before uppercase that follows lowercase,
+				// or before uppercase that starts a new word in a run of capitals.
+				if unicode.IsLower(prev) || (i+1 < len(runes) && unicode.IsLower(runes[i+1])) {
+					result.WriteRune('_')
+				}
+			}
+			result.WriteRune(unicode.ToLower(r))
+		} else {
+			result.WriteRune(r)
+		}
+	}
+	return result.String()
+}
+
+// structToMap converts a struct to map[string]any using db tags with snake_case fallback.
+// Skips unexported fields and fields tagged with db:"-".
+func structToMap(v any) (map[string]any, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("structToMap expects a struct, got %T", v)
+	}
+
+	rt := rv.Type()
+	m := make(map[string]any, rt.NumField())
+
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+
+		// Skip unexported fields
+		if !field.IsExported() {
+			continue
+		}
+
+		// Check db tag
+		tag := field.Tag.Get("db")
+		if tag == "-" {
+			continue
+		}
+
+		// Use tag value or fall back to snake_case
+		colName := tag
+		if colName == "" {
+			colName = toSnakeCase(field.Name)
+		}
+
+		m[colName] = rv.Field(i).Interface()
+	}
+
+	return m, nil
+}
+
+// structsToMaps converts a slice of structs to []map[string]any.
+func structsToMaps(v any) ([]map[string]any, error) {
+	rv := reflect.ValueOf(v)
+	if rv.Kind() == reflect.Ptr {
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("structsToMaps expects a slice, got %T", v)
+	}
+
+	if rv.Len() == 0 {
+		return nil, nil
+	}
+
+	maps := make([]map[string]any, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		elem := rv.Index(i).Interface()
+		m, err := structToMap(elem)
+		if err != nil {
+			return nil, err
+		}
+		maps[i] = m
+	}
+	return maps, nil
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -184,6 +184,71 @@ func (s *Schema) Insert(data any) *query.InsertBuilder {
 	return query.NewInsertBuilder(data, s.dialect, s.execer, err)
 }
 
+// Select starts building a SELECT query with the given columns.
+func (s *Schema) Select(columns ...string) *query.SelectBuilder {
+	err := s.ensureOpen()
+	return query.NewSelectBuilder(columns, s.dialect, s.execer, err)
+}
+
+// Update starts building an UPDATE query for the given table.
+func (s *Schema) Update(table string) *query.UpdateBuilder {
+	err := s.ensureOpen()
+	return query.NewUpdateBuilder(table, s.dialect, s.execer, err)
+}
+
+// Delete starts building a DELETE query for the given table.
+func (s *Schema) Delete(table string) *query.DeleteBuilder {
+	err := s.ensureOpen()
+	return query.NewDeleteBuilder(table, s.dialect, s.execer, err)
+}
+
+// Transaction runs fn inside a database transaction.
+// Automatically commits on nil return, rolls back on error.
+func (s *Schema) Transaction(fn func(tx *Schema) error) error {
+	if err := s.ensureOpen(); err != nil {
+		return err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	txSchema := s.WithTx(tx)
+	if err := fn(txSchema); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit()
+}
+
+// TxSchema is a Schema scoped to an active transaction.
+// Use Commit() or Rollback() to finalize the transaction.
+type TxSchema struct {
+	*Schema
+	tx *sql.Tx
+}
+
+// Commit commits the transaction.
+func (t *TxSchema) Commit() error {
+	return t.tx.Commit()
+}
+
+// Rollback aborts the transaction.
+func (t *TxSchema) Rollback() error {
+	return t.tx.Rollback()
+}
+
+// Begin starts a new transaction and returns a TxSchema for manual commit/rollback control.
+func (s *Schema) Begin() (*TxSchema, error) {
+	if err := s.ensureOpen(); err != nil {
+		return nil, err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	return &TxSchema{Schema: s.WithTx(tx), tx: tx}, nil
+}
+
 func (s *Schema) Table(name string, builder func(t *Table)) {
 	t := NewTable(name)
 	t.Schema = s.schema // Set schema context

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -4,9 +4,11 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/Grandbusta/jone/config"
 	"github.com/Grandbusta/jone/dialect"
+	"github.com/Grandbusta/jone/query"
 )
 
 // Execer is an interface for executing SQL (both *sql.DB and *sql.Tx).
@@ -18,11 +20,13 @@ type Execer interface {
 
 // Schema provides methods for database schema operations.
 type Schema struct {
-	dialect dialect.Dialect
-	db      *sql.DB // original connection (for Begin, Close)
-	execer  Execer  // current executor (db or tx)
-	config  *config.Config
-	schema  string // current schema context
+	dialect  dialect.Dialect
+	db       *sql.DB // original connection (for Begin, Close)
+	execer   Execer  // current executor (db or tx)
+	config   *config.Config
+	schema   string // current schema context
+	openOnce sync.Once
+	openErr  error
 }
 
 // fatal logs the error and exits. Used for unrecoverable schema errors during migrations.
@@ -94,10 +98,34 @@ func (s *Schema) SetDB(db *sql.DB) {
 	s.execer = db
 }
 
+// ensureOpen lazily opens the database connection on first use.
+// Safe for concurrent use — only connects once.
+func (s *Schema) ensureOpen() error {
+	s.openOnce.Do(func() {
+		if s.db != nil {
+			return // already opened explicitly via Open()
+		}
+		s.openErr = s.open()
+	})
+	return s.openErr
+}
+
 // Open opens a database connection using the config.
-// It uses the dialect to determine the driver and DSN format, and applies
-// any connection pool settings from the config.
+// Can be called explicitly for eager connection, or left to ensureOpen for lazy connection.
 func (s *Schema) Open() error {
+	var err error
+	s.openOnce.Do(func() {
+		err = s.open()
+		s.openErr = err
+	})
+	if err != nil {
+		return err
+	}
+	return s.openErr
+}
+
+// open is the internal connection logic.
+func (s *Schema) open() error {
 	driver := s.dialect.DriverName()
 	dsn := s.dialect.FormatDSN(s.config.Connection)
 	db, err := sql.Open(driver, dsn)
@@ -147,6 +175,13 @@ func (s *Schema) Raw(sqlStmt string, args ...any) {
 	} else {
 		fmt.Println(sqlStmt)
 	}
+}
+
+// Insert starts building an INSERT query with the given data.
+// Accepts map[string]any for a single row, or []map[string]any for multiple rows.
+func (s *Schema) Insert(data any) *query.InsertBuilder {
+	err := s.ensureOpen()
+	return query.NewInsertBuilder(data, s.dialect, s.execer, err)
 }
 
 func (s *Schema) Table(name string, builder func(t *Table)) {

--- a/types/types.go
+++ b/types/types.go
@@ -2,6 +2,22 @@
 // This package has no internal dependencies to prevent import cycles.
 package types
 
+// RawExpr represents a raw SQL expression that should not be parameterized or quoted.
+type RawExpr struct {
+	Expr string
+}
+
+// Functions provides SQL function helpers.
+type Functions struct{}
+
+// Now returns a raw CURRENT_TIMESTAMP expression.
+func (f *Functions) Now() RawExpr {
+	return RawExpr{Expr: "CURRENT_TIMESTAMP"}
+}
+
+// Fn is the global functions instance for use as jone.Fn.Now(), etc.
+var Fn = &Functions{}
+
 // ActionType represents the type of table alteration action.
 type ActionType string
 


### PR DESCRIPTION
## Summary

v0.3.0 introduces a fluent query builder alongside the existing migration tooling.

### Query builder
- `jone.New()` with lazy connection — connects automatically on first query; generated `jonefile.go` now exports a ready-to-use `DB` instance
- **INSERT**: `map`, `[]map`, struct, and `[]struct` input (`db` tags with snake_case fallback), `OnConflict().Ignore()` with column/partial-index targets
- **SELECT**: column selection, injection-safe `OrderBy`/`OrderByRaw`, `Limit`/`Offset`, `Exec()` returning `*sql.Rows`, `First()` returning `map[string]any`
- **UPDATE / DELETE**: parameterized `Set` and WHERE across the board
- **Parameterized WHERE family** on Select/Update/Delete: `Where`, `OrWhere`, `WhereIn`/`WhereNotIn`, `WhereNull`/`WhereNotNull`, `WhereRaw` (`?` rebound to `$n` on PostgreSQL)
- **Condition groups**: `Where(func(g *jone.WhereGroup) {...})` for parenthesized, nestable groups
- **`ExecReturning()`** on Insert/Update/Delete — PostgreSQL `RETURNING`, rows back as `[]map[string]any` (fixes `LastInsertId()` being unusable on PostgreSQL)
- **Transactions**: `db.Transaction(fn)` auto commit/rollback and manual `db.Begin()` → `Commit()`/`Rollback()`
- `jone.Raw()` / `jone.Fn.Now()` raw SQL expressions; `ToSQL()` on every builder

### Under the hood
- Dialect-level SQL generation for all DML with correct PostgreSQL parameter numbering (WHERE params continue after SET)
- Deterministic column ordering, deferred-error pattern surfacing at `Exec()`
- Extensive exact-SQL test coverage for both dialects plus builder tests on a stub driver