### PR TITLE
v0.4.0 Query builder enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,15 +338,31 @@ rows, err := jonecfg.DB.Select("id", "name").From("users").
 // First row as a map (sql.ErrNoRows if none)
 row, err := jonecfg.DB.Select("*").From("users").Where("id", 1).First()
 
-// UPDATE — SET and WHERE are both parameterized
-result, err := jonecfg.DB.Update("users").
-    Set("name", "Alice").
-    Set("updated_at", jone.Fn.Now()).
-    Where("id", 1).
-    Exec()
+// All rows as []map[string]any (empty when none match)
+users, err := jonecfg.DB.Select("*").From("users").Where("active", true).All()
+
+// Derived tables — name a subquery with As() and select from it
+sub := jone.Select("user_id").From("orders").GroupBy("user_id").As("t")
+rows, err := jonecfg.DB.Select("*").From(sub).Exec()
+
+// UPDATE — the data is passed directly to Update; SET and WHERE are both
+// parameterized
+result, err := jonecfg.DB.Update("users", map[string]any{
+    "name":       "Alice",
+    "updated_at": jone.Fn.Now(),
+}).Where("id", 1).Exec()
+
+// Structs work too, using `db` tags with snake_case fallback (same as Insert),
+// and there's a single-pair shorthand
+result, err = jonecfg.DB.Update("users", user).Where("id", 1).Exec()
+result, err = jonecfg.DB.Update("books", "title", "Slaughterhouse Five").Where("id", 42).Exec()
 
 // DELETE
 result, err := jonecfg.DB.Delete("users").Where("active", false).Exec()
+
+// Raw SQL — ? placeholders are rebound per dialect ($n on PostgreSQL)
+rows, err := jonecfg.DB.RawQuery("SELECT * FROM users WHERE age > ?", 21).All()
+result, err = jonecfg.DB.RawQuery("UPDATE users SET status = ? WHERE id = ?", "legacy", 7).Exec()
 ```
 
 ## 📝 Migration Example

--- a/README.md
+++ b/README.md
@@ -352,6 +352,15 @@ rows, err := jonecfg.DB.Select("users.name", "o.total").From("users").
 sub := jone.Select("user_id").From("orders").GroupBy("user_id").As("t")
 rows, err := jonecfg.DB.Select("*").From(sub).Exec()
 
+// CTEs, unions, and row locking
+rows, err = jonecfg.DB.Select("*").From("totals").
+    With("totals", jone.Select("user_id").From("orders").GroupBy("user_id")).
+    Exec()
+rows, err = jonecfg.DB.Select("name").From("users").
+    Union(jone.Select("name").From("archived_users")).Exec()
+row, err = jonecfg.DB.Select("*").From("jobs").
+    Where("status", "queued").ForUpdate().SkipLocked().First()
+
 // UPDATE — the data is passed directly to Update; SET and WHERE are both
 // parameterized
 result, err := jonecfg.DB.Update("users", map[string]any{

--- a/README.md
+++ b/README.md
@@ -341,6 +341,13 @@ row, err := jonecfg.DB.Select("*").From("users").Where("id", 1).First()
 // All rows as []map[string]any (empty when none match)
 users, err := jonecfg.DB.Select("*").From("users").Where("active", true).All()
 
+// Joins — qualified columns are quoted ("users.id" → "users"."id"),
+// tables support "as" aliasing
+rows, err := jonecfg.DB.Select("users.name", "o.total").From("users").
+    Join("orders as o", "users.id", "o.user_id").
+    Where("o.total", ">", 100).
+    Exec()
+
 // Derived tables — name a subquery with As() and select from it
 sub := jone.Select("user_id").From("orders").GroupBy("user_id").As("t")
 rows, err := jonecfg.DB.Select("*").From(sub).Exec()
@@ -359,6 +366,9 @@ result, err = jonecfg.DB.Update("books", "title", "Slaughterhouse Five").Where("
 
 // DELETE
 result, err := jonecfg.DB.Delete("users").Where("active", false).Exec()
+
+// TRUNCATE — remove all rows
+result, err = jonecfg.DB.Truncate("sessions").Exec()
 
 // Raw SQL — ? placeholders are rebound per dialect ($n on PostgreSQL)
 rows, err := jonecfg.DB.RawQuery("SELECT * FROM users WHERE age > ?", 21).All()

--- a/cmd/jone/cli/version.go
+++ b/cmd/jone/cli/version.go
@@ -8,7 +8,7 @@ import (
 
 // Version is the current version of jone.
 // Update this before each release.
-var Version = "v0.3.0"
+var Version = "v0.4.0"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/dialect/aggregate.go
+++ b/dialect/aggregate.go
@@ -1,0 +1,21 @@
+package dialect
+
+import "fmt"
+
+// aggregateSQL renders a single-value aggregate SELECT shared by all dialects,
+// e.g. SELECT COUNT(*) FROM "users" WHERE ...; A column of "" or "*" compiles
+// to FN(*), anything else is quoted.
+func aggregateSQL(table, fn, column string, wheres []Cond, quote func(string) string, placeholder func(int) string, likeOp func(insensitive bool) string) (string, []any) {
+	expr := fn + "(*)"
+	if column != "" && column != "*" {
+		expr = fn + "(" + quote(column) + ")"
+	}
+
+	sql := fmt.Sprintf("SELECT %s FROM %s", expr, quote(table))
+
+	whereSQL, args := compileWheres(wheres, quote, placeholder, likeOp, 0)
+	if whereSQL != "" {
+		sql += " WHERE " + whereSQL
+	}
+	return sql + ";", args
+}

--- a/dialect/aggregate_test.go
+++ b/dialect/aggregate_test.go
@@ -1,0 +1,97 @@
+package dialect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAggregateSQL(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		fn       string
+		column   string
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:    "postgres count star",
+			dialect: pg,
+			fn:      "COUNT",
+			column:  "*",
+			wantSQL: `SELECT COUNT(*) FROM "users";`,
+		},
+		{
+			name:    "mysql count star",
+			dialect: my,
+			fn:      "COUNT",
+			column:  "*",
+			wantSQL: "SELECT COUNT(*) FROM `users`;",
+		},
+		{
+			name:    "postgres count empty column",
+			dialect: pg,
+			fn:      "COUNT",
+			column:  "",
+			wantSQL: `SELECT COUNT(*) FROM "users";`,
+		},
+		{
+			name:    "postgres sum quotes column",
+			dialect: pg,
+			fn:      "SUM",
+			column:  "amount",
+			wantSQL: `SELECT SUM("amount") FROM "users";`,
+		},
+		{
+			name:    "mysql avg quotes column",
+			dialect: my,
+			fn:      "AVG",
+			column:  "score",
+			wantSQL: "SELECT AVG(`score`) FROM `users`;",
+		},
+		{
+			name:     "postgres count with wheres rebinds placeholders",
+			dialect:  pg,
+			fn:       "COUNT",
+			column:   "*",
+			wheres:   []Cond{{Kind: CondCmp, Column: "age", Op: ">", Value: 18}, {Kind: CondCmp, Column: "active", Op: "=", Value: true}},
+			wantSQL:  `SELECT COUNT(*) FROM "users" WHERE "age" > $1 AND "active" = $2;`,
+			wantArgs: []any{18, true},
+		},
+		{
+			name:     "mysql min with wheres",
+			dialect:  my,
+			fn:       "MIN",
+			column:   "created_at",
+			wheres:   []Cond{{Kind: CondCmp, Column: "status", Op: "=", Value: "active"}},
+			wantSQL:  "SELECT MIN(`created_at`) FROM `users` WHERE `status` = ?;",
+			wantArgs: []any{"active"},
+		},
+		{
+			name:    "postgres max no wheres",
+			dialect: pg,
+			fn:      "MAX",
+			column:  "id",
+			wantSQL: `SELECT MAX("id") FROM "users";`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.AggregateSQL("users", tt.fn, tt.column, tt.wheres)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if len(tt.wantArgs) == 0 && len(args) != 0 {
+				t.Errorf("args = %v, want none", args)
+			}
+			if len(tt.wantArgs) > 0 && !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -85,6 +85,9 @@ type Dialect interface {
 	// e.g. SELECT COUNT(*) / SUM(col) with the given WHERE conditions.
 	AggregateSQL(table, fn, column string, wheres []Cond) (string, []any)
 
+	// TruncateSQL generates a TRUNCATE TABLE statement.
+	TruncateSQL(table string) string
+
 	// UpdateSQL generates a parameterized UPDATE statement.
 	// SET params come first; WHERE params continue the numbering.
 	// returning columns are appended as a RETURNING clause where supported.
@@ -99,6 +102,9 @@ type Dialect interface {
 
 	// SupportsDistinctOn reports whether the dialect supports DISTINCT ON.
 	SupportsDistinctOn() bool
+
+	// SupportsFullOuterJoin reports whether the dialect supports FULL OUTER JOIN.
+	SupportsFullOuterJoin() bool
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -75,7 +75,15 @@ type Dialect interface {
 	InsertManySQL(table string, data []map[string]any, opts InsertOptions) (string, []any)
 
 	// SelectSQL generates a parameterized SELECT statement.
-	SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any)
+	SelectSQL(sub SubSelect) (string, []any)
+
+	// RawSQL rebinds ? placeholders in a raw SQL string to the dialect's
+	// placeholder style, returning the SQL and its bound args.
+	RawSQL(raw string, args []any) (string, []any)
+
+	// AggregateSQL generates a parameterized single-value aggregate SELECT,
+	// e.g. SELECT COUNT(*) / SUM(col) with the given WHERE conditions.
+	AggregateSQL(table, fn, column string, wheres []Cond) (string, []any)
 
 	// UpdateSQL generates a parameterized UPDATE statement.
 	// SET params come first; WHERE params continue the numbering.
@@ -88,6 +96,9 @@ type Dialect interface {
 
 	// SupportsReturning reports whether the dialect supports RETURNING clauses.
 	SupportsReturning() bool
+
+	// SupportsDistinctOn reports whether the dialect supports DISTINCT ON.
+	SupportsDistinctOn() bool
 
 	// --- Migration Tracking Methods ---
 

--- a/dialect/join.go
+++ b/dialect/join.go
@@ -1,0 +1,85 @@
+package dialect
+
+import (
+	"regexp"
+	"strings"
+)
+
+// quoteQualified quotes a possibly dot-qualified identifier segment by
+// segment using quotePart, leaving * segments unquoted.
+func quoteQualified(name string, quotePart func(string) string) string {
+	parts := strings.Split(name, ".")
+	for i, p := range parts {
+		if p == "*" {
+			continue
+		}
+		parts[i] = quotePart(p)
+	}
+	return strings.Join(parts, ".")
+}
+
+var asAliasRe = regexp.MustCompile(`(?i)^(.+?)\s+as\s+(.+)$`)
+
+// quoteTable quotes a table reference, supporting "table as alias":
+// "orders as o" → "orders" AS "o".
+func quoteTable(name string, quote func(string) string) string {
+	if m := asAliasRe.FindStringSubmatch(name); m != nil {
+		return quote(m[1]) + " AS " + quote(m[2])
+	}
+	return quote(name)
+}
+
+// rebindRaw rewrites each ? in a raw fragment to the placeholder produced by
+// next, binding values in order. Every ? is treated as a placeholder,
+// including inside string literals.
+func rebindRaw(raw string, values []any, next func(v any) string) string {
+	var sb strings.Builder
+	valIdx := 0
+	for _, r := range raw {
+		if r == '?' && valIdx < len(values) {
+			sb.WriteString(next(values[valIdx]))
+			valIdx++
+		} else {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+// JoinClause represents a single JOIN built by the query builders.
+type JoinClause struct {
+	Kind   string // "INNER JOIN", "LEFT [OUTER] JOIN", "RIGHT [OUTER] JOIN", "FULL OUTER JOIN", "CROSS JOIN"
+	Table  string // join target; may use "table as alias"
+	Left   string // ON Left Op Right — identifiers, quoted at compile time; empty Left means no ON (CROSS JOIN)
+	Op     string
+	Right  string
+	Raw    string // verbatim join fragment with ? placeholders; wins over the structured form
+	Values []any  // args bound to Raw's ? placeholders
+}
+
+// compileJoins renders JOIN clauses (space-separated, no leading space) and
+// their bound args. startIdx is the count of params already emitted by the
+// caller, so placeholder numbering continues from there.
+func compileJoins(joins []JoinClause, quote func(string) string, placeholder func(int) string, startIdx int) (string, []any) {
+	var args []any
+	paramIdx := startIdx
+
+	next := func(v any) string {
+		paramIdx++
+		args = append(args, v)
+		return placeholder(paramIdx)
+	}
+
+	parts := make([]string, len(joins))
+	for i, j := range joins {
+		if j.Raw != "" {
+			parts[i] = rebindRaw(j.Raw, j.Values, next)
+			continue
+		}
+		parts[i] = j.Kind + " " + quoteTable(j.Table, quote)
+		if j.Left != "" {
+			parts[i] += " ON " + quote(j.Left) + " " + j.Op + " " + quote(j.Right)
+		}
+	}
+	return strings.Join(parts, " "), args
+}

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -29,8 +29,12 @@ func (d *MySQLDialect) FormatDSN(conn config.Connection) string {
 }
 
 // QuoteIdentifier quotes an identifier with backticks for MySQL.
+// QuoteIdentifier quotes an identifier, treating dots as qualification:
+// "users.id" → `users`.`id`. A * segment stays unquoted ("users.*").
 func (d *MySQLDialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf("`%s`", name)
+	return quoteQualified(name, func(part string) string {
+		return "`" + part + "`"
+	})
 }
 
 // CreateTableSQL generates a CREATE TABLE statement for MySQL.
@@ -532,6 +536,11 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 	return sql + ";", args
 }
 
+// TruncateSQL generates a TRUNCATE TABLE statement for MySQL.
+func (d *MySQLDialect) TruncateSQL(table string) string {
+	return fmt.Sprintf("TRUNCATE TABLE %s;", d.QuoteIdentifier(table))
+}
+
 // DeleteSQL generates a parameterized DELETE statement for MySQL.
 // The returning param is ignored — MySQL has no RETURNING support.
 func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
@@ -550,6 +559,11 @@ func (d *MySQLDialect) RawSQL(raw string, args []any) (string, []any) {
 
 // SupportsDistinctOn reports that MySQL does not support DISTINCT ON.
 func (d *MySQLDialect) SupportsDistinctOn() bool {
+	return false
+}
+
+// SupportsFullOuterJoin reports that MySQL does not support FULL OUTER JOIN.
+func (d *MySQLDialect) SupportsFullOuterJoin() bool {
 	return false
 }
 

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -485,37 +485,25 @@ func mysqlPlaceholder(int) string {
 	return "?"
 }
 
+// mysqlLikeOp returns the MySQL LIKE operator. MySQL's default collation is
+// case-insensitive, so plain LIKE covers the insensitive form and LIKE BINARY
+// forces a case-sensitive match.
+func mysqlLikeOp(insensitive bool) string {
+	if insensitive {
+		return "LIKE"
+	}
+	return "LIKE BINARY"
+}
+
 // SelectSQL generates a parameterized SELECT statement for MySQL.
-func (d *MySQLDialect) SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any) {
-	cols := "*"
-	if len(columns) > 0 {
-		quoted := make([]string, len(columns))
-		for i, c := range columns {
-			if c == "*" {
-				quoted[i] = c
-			} else {
-				quoted[i] = d.QuoteIdentifier(c)
-			}
-		}
-		cols = strings.Join(quoted, ", ")
-	}
-
-	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
-
-	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
-	if whereSQL != "" {
-		sql += " WHERE " + whereSQL
-	}
-	if len(orderBys) > 0 {
-		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
-	}
-	if limit != nil {
-		sql += fmt.Sprintf(" LIMIT %d", *limit)
-	}
-	if offset != nil {
-		sql += fmt.Sprintf(" OFFSET %d", *offset)
-	}
+func (d *MySQLDialect) SelectSQL(sub SubSelect) (string, []any) {
+	sql, args := selectSQL(sub, d.QuoteIdentifier, mysqlPlaceholder, mysqlLikeOp, 0)
 	return sql + ";", args
+}
+
+// AggregateSQL generates a parameterized single-value aggregate SELECT for MySQL.
+func (d *MySQLDialect) AggregateSQL(table, fn, column string, wheres []Cond) (string, []any) {
+	return aggregateSQL(table, fn, column, wheres, d.QuoteIdentifier, mysqlPlaceholder, mysqlLikeOp)
 }
 
 // UpdateSQL generates a parameterized UPDATE statement for MySQL.
@@ -536,7 +524,7 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
-	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, mysqlLikeOp, 0)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 		args = append(args, whereArgs...)
@@ -548,11 +536,21 @@ func (d *MySQLDialect) UpdateSQL(table string, set map[string]any, wheres []Cond
 // The returning param is ignored — MySQL has no RETURNING support.
 func (d *MySQLDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
-	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, mysqlPlaceholder, mysqlLikeOp, 0)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 	}
 	return sql + ";", args
+}
+
+// RawSQL rebinds ? placeholders in a raw SQL string; MySQL keeps ? natively.
+func (d *MySQLDialect) RawSQL(raw string, args []any) (string, []any) {
+	return compileWheres([]Cond{{Kind: CondRaw, Raw: raw, Values: args}}, d.QuoteIdentifier, mysqlPlaceholder, mysqlLikeOp, 0)
+}
+
+// SupportsDistinctOn reports that MySQL does not support DISTINCT ON.
+func (d *MySQLDialect) SupportsDistinctOn() bool {
+	return false
 }
 
 // SupportsReturning reports that MySQL does not support RETURNING clauses.

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -32,8 +32,12 @@ func (d *PostgresDialect) FormatDSN(conn config.Connection) string {
 }
 
 // QuoteIdentifier quotes an identifier with double quotes for PostgreSQL.
+// QuoteIdentifier quotes an identifier, treating dots as qualification:
+// "users.id" → "users"."id". A * segment stays unquoted ("users.*").
 func (d *PostgresDialect) QuoteIdentifier(name string) string {
-	return fmt.Sprintf(`"%s"`, name)
+	return quoteQualified(name, func(part string) string {
+		return `"` + part + `"`
+	})
 }
 
 // CreateTableSQL generates a CREATE TABLE statement for PostgreSQL.
@@ -547,6 +551,11 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 	return sql + ";", args
 }
 
+// TruncateSQL generates a TRUNCATE TABLE statement for PostgreSQL.
+func (d *PostgresDialect) TruncateSQL(table string) string {
+	return fmt.Sprintf("TRUNCATE TABLE %s;", d.QuoteIdentifier(table))
+}
+
 // DeleteSQL generates a parameterized DELETE statement for PostgreSQL.
 func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
@@ -565,6 +574,11 @@ func (d *PostgresDialect) RawSQL(raw string, args []any) (string, []any) {
 
 // SupportsDistinctOn reports that PostgreSQL supports DISTINCT ON.
 func (d *PostgresDialect) SupportsDistinctOn() bool {
+	return true
+}
+
+// SupportsFullOuterJoin reports that PostgreSQL supports FULL OUTER JOIN.
+func (d *PostgresDialect) SupportsFullOuterJoin() bool {
 	return true
 }
 

--- a/dialect/postgres.go
+++ b/dialect/postgres.go
@@ -498,37 +498,24 @@ func pgPlaceholder(n int) string {
 	return fmt.Sprintf("$%d", n)
 }
 
+// pgLikeOp returns the PostgreSQL LIKE operator: ILIKE for case-insensitive
+// matches, LIKE for case-sensitive.
+func pgLikeOp(insensitive bool) string {
+	if insensitive {
+		return "ILIKE"
+	}
+	return "LIKE"
+}
+
 // SelectSQL generates a parameterized SELECT statement for PostgreSQL.
-func (d *PostgresDialect) SelectSQL(table string, columns []string, wheres []Cond, orderBys []OrderClause, limit *int, offset *int) (string, []any) {
-	cols := "*"
-	if len(columns) > 0 {
-		quoted := make([]string, len(columns))
-		for i, c := range columns {
-			if c == "*" {
-				quoted[i] = c
-			} else {
-				quoted[i] = d.QuoteIdentifier(c)
-			}
-		}
-		cols = strings.Join(quoted, ", ")
-	}
-
-	sql := fmt.Sprintf("SELECT %s FROM %s", cols, d.QuoteIdentifier(table))
-
-	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
-	if whereSQL != "" {
-		sql += " WHERE " + whereSQL
-	}
-	if len(orderBys) > 0 {
-		sql += " ORDER BY " + compileOrderBys(orderBys, d.QuoteIdentifier)
-	}
-	if limit != nil {
-		sql += fmt.Sprintf(" LIMIT %d", *limit)
-	}
-	if offset != nil {
-		sql += fmt.Sprintf(" OFFSET %d", *offset)
-	}
+func (d *PostgresDialect) SelectSQL(sub SubSelect) (string, []any) {
+	sql, args := selectSQL(sub, d.QuoteIdentifier, pgPlaceholder, pgLikeOp, 0)
 	return sql + ";", args
+}
+
+// AggregateSQL generates a parameterized single-value aggregate SELECT for PostgreSQL.
+func (d *PostgresDialect) AggregateSQL(table, fn, column string, wheres []Cond) (string, []any) {
+	return aggregateSQL(table, fn, column, wheres, d.QuoteIdentifier, pgPlaceholder, pgLikeOp)
 }
 
 // UpdateSQL generates a parameterized UPDATE statement for PostgreSQL.
@@ -551,7 +538,7 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 
 	sql := fmt.Sprintf("UPDATE %s SET %s", d.QuoteIdentifier(table), strings.Join(setClauses, ", "))
 
-	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, paramIdx)
+	whereSQL, whereArgs := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, pgLikeOp, paramIdx)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 		args = append(args, whereArgs...)
@@ -563,12 +550,22 @@ func (d *PostgresDialect) UpdateSQL(table string, set map[string]any, wheres []C
 // DeleteSQL generates a parameterized DELETE statement for PostgreSQL.
 func (d *PostgresDialect) DeleteSQL(table string, wheres []Cond, returning []string) (string, []any) {
 	sql := fmt.Sprintf("DELETE FROM %s", d.QuoteIdentifier(table))
-	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, 0)
+	whereSQL, args := compileWheres(wheres, d.QuoteIdentifier, pgPlaceholder, pgLikeOp, 0)
 	if whereSQL != "" {
 		sql += " WHERE " + whereSQL
 	}
 	sql += returningClause(returning, d.QuoteIdentifier)
 	return sql + ";", args
+}
+
+// RawSQL rebinds ? placeholders in a raw SQL string to $n placeholders.
+func (d *PostgresDialect) RawSQL(raw string, args []any) (string, []any) {
+	return compileWheres([]Cond{{Kind: CondRaw, Raw: raw, Values: args}}, d.QuoteIdentifier, pgPlaceholder, pgLikeOp, 0)
+}
+
+// SupportsDistinctOn reports that PostgreSQL supports DISTINCT ON.
+func (d *PostgresDialect) SupportsDistinctOn() bool {
+	return true
 }
 
 // SupportsReturning reports that PostgreSQL supports RETURNING clauses.

--- a/dialect/postgres_test.go
+++ b/dialect/postgres_test.go
@@ -24,6 +24,9 @@ func TestPostgresDialect_QuoteIdentifier(t *testing.T) {
 		{"users", `"users"`},
 		{"user_id", `"user_id"`},
 		{"CamelCase", `"CamelCase"`},
+		{"users.id", `"users"."id"`},
+		{"users.*", `"users".*`},
+		{"*", `*`},
 	}
 	for _, tt := range tests {
 		if got := d.QuoteIdentifier(tt.input); got != tt.want {

--- a/dialect/select.go
+++ b/dialect/select.go
@@ -9,19 +9,39 @@ import (
 // body of the public SelectSQL methods and for EXISTS subqueries, where it
 // compiles inline with the outer query's placeholder numbering.
 type SubSelect struct {
+	CTEs       []CTE // WITH clauses, rendered (and numbered) before everything
 	Table      string
 	FromSub    *SubSelect // derived-table FROM: (subquery) AS FromAlias; wins over Table
 	FromAlias  string     // required alias for FromSub (both dialects demand one)
-	Columns    []string
-	Distinct   bool     // SELECT DISTINCT
-	DistinctOn []string // SELECT DISTINCT ON (cols) — PostgreSQL only; wins over Distinct
+	Columns    []string   // may use "col as alias"
+	Distinct   bool       // SELECT DISTINCT
+	DistinctOn []string   // SELECT DISTINCT ON (cols) — PostgreSQL only; wins over Distinct
 	Joins      []JoinClause
 	Wheres     []Cond
 	GroupBys   []GroupClause
 	Havings    []Cond
+	Unions     []UnionClause // rendered after HAVING; ORDER BY/LIMIT apply to the combined result
 	OrderBys   []OrderClause
 	Limit      *int
 	Offset     *int
+	Lock       string // row-locking suffix, e.g. "FOR UPDATE SKIP LOCKED"; rendered last
+}
+
+// CTE is a single WITH clause: Name AS (subquery).
+type CTE struct {
+	Name      string
+	Recursive bool       // any recursive CTE puts RECURSIVE after WITH (it applies to the whole list)
+	Sub       *SubSelect // builder-form body
+	Raw       string     // raw body with ? placeholders; wins over Sub
+	Values    []any
+}
+
+// UnionClause combines another SELECT with UNION or UNION ALL.
+type UnionClause struct {
+	All    bool
+	Sub    *SubSelect // builder-form query
+	Raw    string     // raw query with ? placeholders; wins over Sub
+	Values []any
 }
 
 // GroupClause represents a single GROUP BY term built by the query builders.
@@ -46,8 +66,51 @@ func compileGroupBys(groups []GroupClause, quote func(string) string) string {
 // selectSQL renders a SELECT statement (without the trailing semicolon, so it
 // can nest inside EXISTS parentheses) shared by all dialects. startIdx is the
 // count of params already emitted by the caller, so placeholder numbering
-// continues from there.
+// continues from there. Args accumulate in textual order: CTEs, FROM
+// subquery, joins, WHERE, HAVING, unions.
 func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) string, likeOp func(insensitive bool) string, startIdx int) (string, []any) {
+	paramIdx := startIdx
+	var args []any
+
+	next := func(v any) string {
+		paramIdx++
+		args = append(args, v)
+		return placeholder(paramIdx)
+	}
+
+	// subBody compiles a nested SubSelect continuing the outer numbering.
+	subBody := func(s *SubSelect) string {
+		body, subArgs := selectSQL(*s, quote, placeholder, likeOp, paramIdx)
+		paramIdx += len(subArgs)
+		args = append(args, subArgs...)
+		return body
+	}
+
+	var sb strings.Builder
+
+	if len(sub.CTEs) > 0 {
+		sb.WriteString("WITH ")
+		for _, c := range sub.CTEs {
+			if c.Recursive {
+				sb.WriteString("RECURSIVE ")
+				break
+			}
+		}
+		for i, c := range sub.CTEs {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			body := ""
+			if c.Raw != "" {
+				body = rebindRaw(c.Raw, c.Values, next)
+			} else {
+				body = subBody(c.Sub)
+			}
+			sb.WriteString(quote(c.Name) + " AS (" + body + ")")
+		}
+		sb.WriteString(" ")
+	}
+
 	cols := "*"
 	if len(sub.Columns) > 0 {
 		quoted := make([]string, len(sub.Columns))
@@ -55,7 +118,7 @@ func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) s
 			if c == "*" {
 				quoted[i] = c
 			} else {
-				quoted[i] = quote(c)
+				quoted[i] = quoteTable(c, quote) // handles "col as alias" too
 			}
 		}
 		cols = strings.Join(quoted, ", ")
@@ -73,47 +136,59 @@ func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) s
 	}
 
 	from := quoteTable(sub.Table, quote)
-	var args []any
 	if sub.FromSub != nil {
-		body, fromArgs := selectSQL(*sub.FromSub, quote, placeholder, likeOp, startIdx)
-		from = "(" + body + ") AS " + quote(sub.FromAlias)
-		args = fromArgs
-		startIdx += len(fromArgs)
+		from = "(" + subBody(sub.FromSub) + ") AS " + quote(sub.FromAlias)
 	}
 
-	sql := fmt.Sprintf("SELECT %s%s FROM %s", distinct, cols, from)
+	fmt.Fprintf(&sb, "SELECT %s%s FROM %s", distinct, cols, from)
 
 	if len(sub.Joins) > 0 {
-		joinSQL, joinArgs := compileJoins(sub.Joins, quote, placeholder, startIdx)
-		sql += " " + joinSQL
+		joinSQL, joinArgs := compileJoins(sub.Joins, quote, placeholder, paramIdx)
+		sb.WriteString(" " + joinSQL)
+		paramIdx += len(joinArgs)
 		args = append(args, joinArgs...)
-		startIdx += len(joinArgs)
 	}
 
-	whereSQL, whereArgs := compileWheres(sub.Wheres, quote, placeholder, likeOp, startIdx)
+	whereSQL, whereArgs := compileWheres(sub.Wheres, quote, placeholder, likeOp, paramIdx)
 	if whereSQL != "" {
-		sql += " WHERE " + whereSQL
+		sb.WriteString(" WHERE " + whereSQL)
 	}
+	paramIdx += len(whereArgs)
 	args = append(args, whereArgs...)
-	startIdx += len(whereArgs)
+
 	if len(sub.GroupBys) > 0 {
-		sql += " GROUP BY " + compileGroupBys(sub.GroupBys, quote)
+		sb.WriteString(" GROUP BY " + compileGroupBys(sub.GroupBys, quote))
 	}
 	if len(sub.Havings) > 0 {
-		havingSQL, havingArgs := compileWheres(sub.Havings, quote, placeholder, likeOp, startIdx)
+		havingSQL, havingArgs := compileWheres(sub.Havings, quote, placeholder, likeOp, paramIdx)
 		if havingSQL != "" {
-			sql += " HAVING " + havingSQL
+			sb.WriteString(" HAVING " + havingSQL)
+			paramIdx += len(havingArgs)
 			args = append(args, havingArgs...)
 		}
 	}
+	for _, u := range sub.Unions {
+		op := " UNION "
+		if u.All {
+			op = " UNION ALL "
+		}
+		if u.Raw != "" {
+			sb.WriteString(op + rebindRaw(u.Raw, u.Values, next))
+		} else {
+			sb.WriteString(op + subBody(u.Sub))
+		}
+	}
 	if len(sub.OrderBys) > 0 {
-		sql += " ORDER BY " + compileOrderBys(sub.OrderBys, quote)
+		sb.WriteString(" ORDER BY " + compileOrderBys(sub.OrderBys, quote))
 	}
 	if sub.Limit != nil {
-		sql += fmt.Sprintf(" LIMIT %d", *sub.Limit)
+		fmt.Fprintf(&sb, " LIMIT %d", *sub.Limit)
 	}
 	if sub.Offset != nil {
-		sql += fmt.Sprintf(" OFFSET %d", *sub.Offset)
+		fmt.Fprintf(&sb, " OFFSET %d", *sub.Offset)
 	}
-	return sql, args
+	if sub.Lock != "" {
+		sb.WriteString(" " + sub.Lock)
+	}
+	return sb.String(), args
 }

--- a/dialect/select.go
+++ b/dialect/select.go
@@ -15,6 +15,7 @@ type SubSelect struct {
 	Columns    []string
 	Distinct   bool     // SELECT DISTINCT
 	DistinctOn []string // SELECT DISTINCT ON (cols) — PostgreSQL only; wins over Distinct
+	Joins      []JoinClause
 	Wheres     []Cond
 	GroupBys   []GroupClause
 	Havings    []Cond
@@ -71,7 +72,7 @@ func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) s
 		distinct = "DISTINCT "
 	}
 
-	from := quote(sub.Table)
+	from := quoteTable(sub.Table, quote)
 	var args []any
 	if sub.FromSub != nil {
 		body, fromArgs := selectSQL(*sub.FromSub, quote, placeholder, likeOp, startIdx)
@@ -81,6 +82,13 @@ func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) s
 	}
 
 	sql := fmt.Sprintf("SELECT %s%s FROM %s", distinct, cols, from)
+
+	if len(sub.Joins) > 0 {
+		joinSQL, joinArgs := compileJoins(sub.Joins, quote, placeholder, startIdx)
+		sql += " " + joinSQL
+		args = append(args, joinArgs...)
+		startIdx += len(joinArgs)
+	}
 
 	whereSQL, whereArgs := compileWheres(sub.Wheres, quote, placeholder, likeOp, startIdx)
 	if whereSQL != "" {

--- a/dialect/select.go
+++ b/dialect/select.go
@@ -1,0 +1,111 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SubSelect is a neutral description of a SELECT statement, used both as the
+// body of the public SelectSQL methods and for EXISTS subqueries, where it
+// compiles inline with the outer query's placeholder numbering.
+type SubSelect struct {
+	Table      string
+	FromSub    *SubSelect // derived-table FROM: (subquery) AS FromAlias; wins over Table
+	FromAlias  string     // required alias for FromSub (both dialects demand one)
+	Columns    []string
+	Distinct   bool     // SELECT DISTINCT
+	DistinctOn []string // SELECT DISTINCT ON (cols) — PostgreSQL only; wins over Distinct
+	Wheres     []Cond
+	GroupBys   []GroupClause
+	Havings    []Cond
+	OrderBys   []OrderClause
+	Limit      *int
+	Offset     *int
+}
+
+// GroupClause represents a single GROUP BY term built by the query builders.
+type GroupClause struct {
+	Column string // quoted with QuoteIdentifier at compile time
+	Raw    string // raw SQL used verbatim; takes precedence over Column
+}
+
+// compileGroupBys renders the GROUP BY clause body (without the "GROUP BY " prefix).
+func compileGroupBys(groups []GroupClause, quote func(string) string) string {
+	parts := make([]string, len(groups))
+	for i, g := range groups {
+		if g.Raw != "" {
+			parts[i] = g.Raw
+			continue
+		}
+		parts[i] = quote(g.Column)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// selectSQL renders a SELECT statement (without the trailing semicolon, so it
+// can nest inside EXISTS parentheses) shared by all dialects. startIdx is the
+// count of params already emitted by the caller, so placeholder numbering
+// continues from there.
+func selectSQL(sub SubSelect, quote func(string) string, placeholder func(int) string, likeOp func(insensitive bool) string, startIdx int) (string, []any) {
+	cols := "*"
+	if len(sub.Columns) > 0 {
+		quoted := make([]string, len(sub.Columns))
+		for i, c := range sub.Columns {
+			if c == "*" {
+				quoted[i] = c
+			} else {
+				quoted[i] = quote(c)
+			}
+		}
+		cols = strings.Join(quoted, ", ")
+	}
+
+	distinct := ""
+	if len(sub.DistinctOn) > 0 {
+		quoted := make([]string, len(sub.DistinctOn))
+		for i, c := range sub.DistinctOn {
+			quoted[i] = quote(c)
+		}
+		distinct = "DISTINCT ON (" + strings.Join(quoted, ", ") + ") "
+	} else if sub.Distinct {
+		distinct = "DISTINCT "
+	}
+
+	from := quote(sub.Table)
+	var args []any
+	if sub.FromSub != nil {
+		body, fromArgs := selectSQL(*sub.FromSub, quote, placeholder, likeOp, startIdx)
+		from = "(" + body + ") AS " + quote(sub.FromAlias)
+		args = fromArgs
+		startIdx += len(fromArgs)
+	}
+
+	sql := fmt.Sprintf("SELECT %s%s FROM %s", distinct, cols, from)
+
+	whereSQL, whereArgs := compileWheres(sub.Wheres, quote, placeholder, likeOp, startIdx)
+	if whereSQL != "" {
+		sql += " WHERE " + whereSQL
+	}
+	args = append(args, whereArgs...)
+	startIdx += len(whereArgs)
+	if len(sub.GroupBys) > 0 {
+		sql += " GROUP BY " + compileGroupBys(sub.GroupBys, quote)
+	}
+	if len(sub.Havings) > 0 {
+		havingSQL, havingArgs := compileWheres(sub.Havings, quote, placeholder, likeOp, startIdx)
+		if havingSQL != "" {
+			sql += " HAVING " + havingSQL
+			args = append(args, havingArgs...)
+		}
+	}
+	if len(sub.OrderBys) > 0 {
+		sql += " ORDER BY " + compileOrderBys(sub.OrderBys, quote)
+	}
+	if sub.Limit != nil {
+		sql += fmt.Sprintf(" LIMIT %d", *sub.Limit)
+	}
+	if sub.Offset != nil {
+		sql += fmt.Sprintf(" OFFSET %d", *sub.Offset)
+	}
+	return sql, args
+}

--- a/dialect/select_test.go
+++ b/dialect/select_test.go
@@ -1,0 +1,172 @@
+package dialect
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectSQL_DistinctAndGroupBy(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+	ten := 10
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		sub      SubSelect
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:    "postgres distinct star",
+			dialect: pg,
+			sub:     SubSelect{Table: "users", Distinct: true},
+			wantSQL: `SELECT DISTINCT * FROM "users";`,
+		},
+		{
+			name:    "mysql distinct with columns",
+			dialect: my,
+			sub:     SubSelect{Table: "users", Distinct: true, Columns: []string{"city", "state"}},
+			wantSQL: "SELECT DISTINCT `city`, `state` FROM `users`;",
+		},
+		{
+			name:    "postgres distinct on single column",
+			dialect: pg,
+			sub:     SubSelect{Table: "logins", DistinctOn: []string{"user_id"}},
+			wantSQL: `SELECT DISTINCT ON ("user_id") * FROM "logins";`,
+		},
+		{
+			name:    "postgres distinct on two columns wins over distinct flag",
+			dialect: pg,
+			sub:     SubSelect{Table: "logins", Distinct: true, DistinctOn: []string{"user_id", "device"}},
+			wantSQL: `SELECT DISTINCT ON ("user_id", "device") * FROM "logins";`,
+		},
+		{
+			name:    "postgres group by quoted columns",
+			dialect: pg,
+			sub:     SubSelect{Table: "orders", GroupBys: []GroupClause{{Column: "status"}, {Column: "region"}}},
+			wantSQL: `SELECT * FROM "orders" GROUP BY "status", "region";`,
+		},
+		{
+			name:    "mysql group by raw",
+			dialect: my,
+			sub:     SubSelect{Table: "orders", GroupBys: []GroupClause{{Raw: "DATE(created_at)"}}},
+			wantSQL: "SELECT * FROM `orders` GROUP BY DATE(created_at);",
+		},
+		{
+			name:    "postgres full clause order",
+			dialect: pg,
+			sub: SubSelect{
+				Table:    "orders",
+				Columns:  []string{"status"},
+				Distinct: true,
+				Wheres:   []Cond{{Kind: CondCmp, Column: "total", Op: ">", Value: 100}},
+				GroupBys: []GroupClause{{Column: "status"}, {Raw: "DATE(created_at)"}},
+				OrderBys: []OrderClause{{Column: "status", Dir: "ASC"}},
+				Limit:    &ten,
+			},
+			wantSQL:  `SELECT DISTINCT "status" FROM "orders" WHERE "total" > $1 GROUP BY "status", DATE(created_at) ORDER BY "status" ASC LIMIT 10;`,
+			wantArgs: []any{100},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL(tt.sub)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if len(tt.wantArgs) == 0 && len(args) != 0 {
+				t.Errorf("args = %v, want none", args)
+			}
+			if len(tt.wantArgs) > 0 && !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestSelectSQL_Having(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		sub      SubSelect
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:    "postgres having after group by",
+			dialect: pg,
+			sub: SubSelect{
+				Table:    "orders",
+				Columns:  []string{"status"},
+				GroupBys: []GroupClause{{Column: "status"}},
+				Havings:  []Cond{{Kind: CondCmp, Column: "count", Op: ">", Value: 5}},
+			},
+			wantSQL:  `SELECT "status" FROM "orders" GROUP BY "status" HAVING "count" > $1;`,
+			wantArgs: []any{5},
+		},
+		{
+			name:    "mysql having after group by",
+			dialect: my,
+			sub: SubSelect{
+				Table:    "orders",
+				GroupBys: []GroupClause{{Column: "status"}},
+				Havings:  []Cond{{Kind: CondCmp, Column: "total", Op: ">=", Value: 100}},
+			},
+			wantSQL:  "SELECT * FROM `orders` GROUP BY `status` HAVING `total` >= ?;",
+			wantArgs: []any{100},
+		},
+		{
+			name:    "postgres having numbering continues past where",
+			dialect: pg,
+			sub: SubSelect{
+				Table:    "orders",
+				Wheres:   []Cond{{Kind: CondCmp, Column: "region", Op: "=", Value: "eu"}},
+				GroupBys: []GroupClause{{Column: "status"}},
+				Havings: []Cond{
+					{Kind: CondCmp, Column: "c", Op: ">", Value: 5},
+					{Kind: CondCmp, Column: "sum", Op: "<", Value: 999},
+				},
+			},
+			wantSQL:  `SELECT * FROM "orders" WHERE "region" = $1 GROUP BY "status" HAVING "c" > $2 AND "sum" < $3;`,
+			wantArgs: []any{"eu", 5, 999},
+		},
+		{
+			name:    "postgres having without group by",
+			dialect: pg,
+			sub: SubSelect{
+				Table:   "orders",
+				Havings: []Cond{{Kind: CondCmp, Column: "total", Op: ">", Value: 0}},
+			},
+			wantSQL:  `SELECT * FROM "orders" HAVING "total" > $1;`,
+			wantArgs: []any{0},
+		},
+		{
+			name:    "postgres having raw rebinds placeholders",
+			dialect: pg,
+			sub: SubSelect{
+				Table:    "orders",
+				GroupBys: []GroupClause{{Column: "status"}},
+				Havings:  []Cond{{Kind: CondRaw, Raw: "COUNT(*) > ?", Values: []any{5}}},
+			},
+			wantSQL:  `SELECT * FROM "orders" GROUP BY "status" HAVING COUNT(*) > $1;`,
+			wantArgs: []any{5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL(tt.sub)
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}

--- a/dialect/where.go
+++ b/dialect/where.go
@@ -19,24 +19,41 @@ const (
 	CondRaw
 	// CondGroup is a parenthesized sub-group of conditions.
 	CondGroup
+	// CondBetween is a range check: Column BETWEEN Values[0] AND Values[1].
+	// Not flips it to NOT BETWEEN.
+	CondBetween
+	// CondExists is an EXISTS (subquery) check: Sub holds a builder-form
+	// subquery, or Raw/Values hold a raw subquery with ? placeholders.
+	// Not flips it to NOT EXISTS.
+	CondExists
+	// CondLike is a pattern match: Column LIKE Value. Insensitive selects the
+	// dialect's case-insensitive form (ILIKE on PostgreSQL, plain LIKE on
+	// MySQL); the sensitive form is LIKE on PostgreSQL, LIKE BINARY on MySQL.
+	// Not flips it to NOT ... .
+	CondLike
 )
 
 // Cond represents a single WHERE condition built by the query builders.
 type Cond struct {
 	Kind   CondKind
 	Or     bool   // join with OR instead of AND (ignored on the first condition)
-	Not    bool   // CondIn → NOT IN, CondNull → IS NOT NULL
+	Not    bool   // CondIn → NOT IN, CondNull → IS NOT NULL, CondCmp/CondGroup → NOT ...
 	Column string // quoted with QuoteIdentifier at compile time
 	Op     string // comparison operator, used verbatim for CondCmp
 	Value  any    // CondCmp bound value
-	Values []any  // CondIn values / CondRaw args
-	Raw    string // CondRaw SQL containing ? placeholders
-	Group  []Cond // CondGroup nested conditions, compiled inside parentheses
+	Values []any      // CondIn values / CondRaw args / CondBetween [low, high]
+	Raw    string     // CondRaw or raw-form CondExists SQL containing ? placeholders
+	Group  []Cond     // CondGroup nested conditions, compiled inside parentheses
+	Sub    *SubSelect // builder-form CondExists subquery
+
+	// Insensitive selects the dialect's case-insensitive operator for CondLike.
+	Insensitive bool
 }
 
 // compileWheres renders the WHERE clause body (without the "WHERE " prefix)
 // and its bound args. quote quotes identifiers; placeholder(n) returns the
 // 1-based placeholder for param n ("$3" for postgres, "?" for mysql);
+// likeOp returns the dialect's LIKE operator for the given case sensitivity;
 // startIdx is the count of params already emitted by the caller (e.g. UPDATE
 // SET args), so placeholder numbering continues from there.
 //
@@ -44,7 +61,7 @@ type Cond struct {
 // flag. Groups compile inside parentheses; empty groups vanish (an empty
 // result string means no condition survived, and the caller should omit the
 // WHERE clause entirely).
-func compileWheres(conds []Cond, quote func(string) string, placeholder func(int) string, startIdx int) (string, []any) {
+func compileWheres(conds []Cond, quote func(string) string, placeholder func(int) string, likeOp func(insensitive bool) string, startIdx int) (string, []any) {
 	var args []any
 	paramIdx := startIdx
 
@@ -52,6 +69,23 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 		paramIdx++
 		args = append(args, v)
 		return placeholder(paramIdx)
+	}
+
+	// renderRaw rewrites each ? in a raw fragment to the dialect placeholder,
+	// binding values in order. Every ? is treated as a placeholder, including
+	// inside string literals.
+	renderRaw := func(raw string, values []any) string {
+		var sb strings.Builder
+		valIdx := 0
+		for _, r := range raw {
+			if r == '?' && valIdx < len(values) {
+				sb.WriteString(nextPlaceholder(values[valIdx]))
+				valIdx++
+			} else {
+				sb.WriteRune(r)
+			}
+		}
+		return sb.String()
 	}
 
 	// renderCond returns the SQL fragment for one condition, or "" if it
@@ -62,7 +96,11 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 	renderCond = func(c Cond) string {
 		switch c.Kind {
 		case CondCmp:
-			return fmt.Sprintf("%s %s %s", quote(c.Column), c.Op, nextPlaceholder(c.Value))
+			frag := fmt.Sprintf("%s %s %s", quote(c.Column), c.Op, nextPlaceholder(c.Value))
+			if c.Not {
+				return "NOT " + frag
+			}
+			return frag
 		case CondIn:
 			if len(c.Values) == 0 {
 				// Empty IN matches nothing; empty NOT IN matches everything.
@@ -86,23 +124,40 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 			}
 			return quote(c.Column) + " IS NULL"
 		case CondRaw:
-			// Rewrite each ? to the dialect placeholder, binding Values in order.
-			// Every ? is treated as a placeholder, including inside string literals.
-			var sb strings.Builder
-			valIdx := 0
-			for _, r := range c.Raw {
-				if r == '?' && valIdx < len(c.Values) {
-					sb.WriteString(nextPlaceholder(c.Values[valIdx]))
-					valIdx++
-				} else {
-					sb.WriteRune(r)
-				}
+			return renderRaw(c.Raw, c.Values)
+		case CondLike:
+			frag := fmt.Sprintf("%s %s %s", quote(c.Column), likeOp(c.Insensitive), nextPlaceholder(c.Value))
+			if c.Not {
+				return "NOT " + frag
 			}
-			return sb.String()
+			return frag
+		case CondBetween:
+			op := "BETWEEN"
+			if c.Not {
+				op = "NOT BETWEEN"
+			}
+			return fmt.Sprintf("%s %s %s AND %s", quote(c.Column), op, nextPlaceholder(c.Values[0]), nextPlaceholder(c.Values[1]))
+		case CondExists:
+			var body string
+			if c.Sub != nil {
+				var subArgs []any
+				body, subArgs = selectSQL(*c.Sub, quote, placeholder, likeOp, paramIdx)
+				paramIdx += len(subArgs)
+				args = append(args, subArgs...)
+			} else {
+				body = renderRaw(c.Raw, c.Values)
+			}
+			if c.Not {
+				return "NOT EXISTS (" + body + ")"
+			}
+			return "EXISTS (" + body + ")"
 		case CondGroup:
 			body := render(c.Group)
 			if body == "" {
 				return ""
+			}
+			if c.Not {
+				return "NOT (" + body + ")"
 			}
 			return "(" + body + ")"
 		}

--- a/dialect/where.go
+++ b/dialect/where.go
@@ -36,11 +36,11 @@ const (
 // Cond represents a single WHERE condition built by the query builders.
 type Cond struct {
 	Kind   CondKind
-	Or     bool   // join with OR instead of AND (ignored on the first condition)
-	Not    bool   // CondIn → NOT IN, CondNull → IS NOT NULL, CondCmp/CondGroup → NOT ...
-	Column string // quoted with QuoteIdentifier at compile time
-	Op     string // comparison operator, used verbatim for CondCmp
-	Value  any    // CondCmp bound value
+	Or     bool       // join with OR instead of AND (ignored on the first condition)
+	Not    bool       // CondIn → NOT IN, CondNull → IS NOT NULL, CondCmp/CondGroup → NOT ...
+	Column string     // quoted with QuoteIdentifier at compile time
+	Op     string     // comparison operator, used verbatim for CondCmp
+	Value  any        // CondCmp bound value
 	Values []any      // CondIn values / CondRaw args / CondBetween [low, high]
 	Raw    string     // CondRaw or raw-form CondExists SQL containing ? placeholders
 	Group  []Cond     // CondGroup nested conditions, compiled inside parentheses
@@ -72,20 +72,9 @@ func compileWheres(conds []Cond, quote func(string) string, placeholder func(int
 	}
 
 	// renderRaw rewrites each ? in a raw fragment to the dialect placeholder,
-	// binding values in order. Every ? is treated as a placeholder, including
-	// inside string literals.
+	// binding values in order.
 	renderRaw := func(raw string, values []any) string {
-		var sb strings.Builder
-		valIdx := 0
-		for _, r := range raw {
-			if r == '?' && valIdx < len(values) {
-				sb.WriteString(nextPlaceholder(values[valIdx]))
-				valIdx++
-			} else {
-				sb.WriteRune(r)
-			}
-		}
-		return sb.String()
+		return rebindRaw(raw, values, nextPlaceholder)
 	}
 
 	// renderCond returns the SQL fragment for one condition, or "" if it

--- a/dialect/where_test.go
+++ b/dialect/where_test.go
@@ -103,7 +103,7 @@ func TestSelectSQL_Wheres(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql, args := tt.dialect.SelectSQL("users", nil, tt.wheres, nil, nil, nil)
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", Wheres: tt.wheres})
 			if sql != tt.wantSQL {
 				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
 			}
@@ -223,7 +223,7 @@ func TestSelectSQL_Groups(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql, args := tt.dialect.SelectSQL("users", nil, tt.wheres, nil, nil, nil)
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", Wheres: tt.wheres})
 			if sql != tt.wantSQL {
 				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
 			}
@@ -317,7 +317,7 @@ func TestSelectSQL_OrderBy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sql, args := tt.dialect.SelectSQL("users", nil, nil, tt.orders, nil, nil)
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", OrderBys: tt.orders})
 			if sql != tt.wantSQL {
 				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
 			}
@@ -405,5 +405,222 @@ func TestDeleteSQL_ReturnsArgs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(args, []any{7}) {
 		t.Errorf("mysql args = %v, want [7]", args)
+	}
+}
+
+func TestSelectSQL_WhereNot(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "postgres not cmp",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondCmp, Not: true, Column: "role", Op: "=", Value: "admin"}},
+			wantSQL:  `SELECT * FROM "users" WHERE NOT "role" = $1;`,
+			wantArgs: []any{"admin"},
+		},
+		{
+			name:     "mysql not cmp",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondCmp, Not: true, Column: "role", Op: "=", Value: "admin"}},
+			wantSQL:  "SELECT * FROM `users` WHERE NOT `role` = ?;",
+			wantArgs: []any{"admin"},
+		},
+		{
+			name:    "postgres not group",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "active", Op: "=", Value: true},
+				{Kind: CondGroup, Not: true, Group: []Cond{
+					{Kind: CondCmp, Column: "role", Op: "=", Value: "admin"},
+					{Kind: CondCmp, Or: true, Column: "age", Op: ">", Value: 65},
+				}},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "active" = $1 AND NOT ("role" = $2 OR "age" > $3);`,
+			wantArgs: []any{true, "admin", 65},
+		},
+		{
+			name:    "postgres not empty group vanishes",
+			dialect: pg,
+			wheres:  []Cond{{Kind: CondGroup, Not: true}},
+			wantSQL: `SELECT * FROM "users";`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", Wheres: tt.wheres})
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if len(tt.wantArgs) == 0 && len(args) != 0 {
+				t.Errorf("args = %v, want none", args)
+			}
+			if len(tt.wantArgs) > 0 && !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestSelectSQL_BetweenAndExists(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+	one := 1
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "postgres between",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondBetween, Column: "age", Values: []any{18, 65}}},
+			wantSQL:  `SELECT * FROM "users" WHERE "age" BETWEEN $1 AND $2;`,
+			wantArgs: []any{18, 65},
+		},
+		{
+			name:     "mysql not between",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondBetween, Not: true, Column: "age", Values: []any{18, 65}}},
+			wantSQL:  "SELECT * FROM `users` WHERE `age` NOT BETWEEN ? AND ?;",
+			wantArgs: []any{18, 65},
+		},
+		{
+			name:    "postgres exists subselect renumbers across boundary",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "active", Op: "=", Value: true},
+				{Kind: CondExists, Sub: &SubSelect{
+					Table:   "orders",
+					Columns: []string{"1"},
+					Wheres: []Cond{
+						{Kind: CondRaw, Raw: "orders.user_id = users.id"},
+						{Kind: CondCmp, Column: "status", Op: "=", Value: "paid"},
+					},
+				}},
+				{Kind: CondCmp, Column: "plan", Op: "=", Value: "pro"},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "active" = $1 AND EXISTS (SELECT "1" FROM "orders" WHERE orders.user_id = users.id AND "status" = $2) AND "plan" = $3;`,
+			wantArgs: []any{true, "paid", "pro"},
+		},
+		{
+			name:    "mysql not exists with limit no trailing semicolon inside",
+			dialect: my,
+			wheres: []Cond{
+				{Kind: CondExists, Not: true, Sub: &SubSelect{
+					Table: "orders",
+					Wheres: []Cond{
+						{Kind: CondCmp, Column: "status", Op: "=", Value: "open"},
+					},
+					Limit: &one,
+				}},
+			},
+			wantSQL:  "SELECT * FROM `users` WHERE NOT EXISTS (SELECT * FROM `orders` WHERE `status` = ? LIMIT 1);",
+			wantArgs: []any{"open"},
+		},
+		{
+			name:    "postgres raw exists rebinds placeholders",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "active", Op: "=", Value: true},
+				{Kind: CondExists, Raw: "SELECT 1 FROM orders WHERE user_id = users.id AND status = ?", Values: []any{"paid"}},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "active" = $1 AND EXISTS (SELECT 1 FROM orders WHERE user_id = users.id AND status = $2);`,
+			wantArgs: []any{true, "paid"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", Wheres: tt.wheres})
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestSelectSQL_Like(t *testing.T) {
+	pg := &PostgresDialect{}
+	my := &MySQLDialect{}
+
+	tests := []struct {
+		name     string
+		dialect  Dialect
+		wheres   []Cond
+		wantSQL  string
+		wantArgs []any
+	}{
+		{
+			name:     "postgres like is case-sensitive",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondLike, Column: "name", Value: "Jo%"}},
+			wantSQL:  `SELECT * FROM "users" WHERE "name" LIKE $1;`,
+			wantArgs: []any{"Jo%"},
+		},
+		{
+			name:     "postgres ilike is case-insensitive",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondLike, Insensitive: true, Column: "name", Value: "jo%"}},
+			wantSQL:  `SELECT * FROM "users" WHERE "name" ILIKE $1;`,
+			wantArgs: []any{"jo%"},
+		},
+		{
+			name:     "mysql like binary is case-sensitive",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondLike, Column: "name", Value: "Jo%"}},
+			wantSQL:  "SELECT * FROM `users` WHERE `name` LIKE BINARY ?;",
+			wantArgs: []any{"Jo%"},
+		},
+		{
+			name:     "mysql plain like is case-insensitive",
+			dialect:  my,
+			wheres:   []Cond{{Kind: CondLike, Insensitive: true, Column: "name", Value: "jo%"}},
+			wantSQL:  "SELECT * FROM `users` WHERE `name` LIKE ?;",
+			wantArgs: []any{"jo%"},
+		},
+		{
+			name:     "postgres not like",
+			dialect:  pg,
+			wheres:   []Cond{{Kind: CondLike, Not: true, Column: "name", Value: "spam%"}},
+			wantSQL:  `SELECT * FROM "users" WHERE NOT "name" LIKE $1;`,
+			wantArgs: []any{"spam%"},
+		},
+		{
+			name:    "postgres like numbering continues",
+			dialect: pg,
+			wheres: []Cond{
+				{Kind: CondCmp, Column: "active", Op: "=", Value: true},
+				{Kind: CondLike, Or: true, Insensitive: true, Column: "email", Value: "%@x.com"},
+			},
+			wantSQL:  `SELECT * FROM "users" WHERE "active" = $1 OR "email" ILIKE $2;`,
+			wantArgs: []any{true, "%@x.com"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql, args := tt.dialect.SelectSQL(SubSelect{Table: "users", Wheres: tt.wheres})
+			if sql != tt.wantSQL {
+				t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+			}
+			if !reflect.DeepEqual(args, tt.wantArgs) {
+				t.Errorf("args = %v, want %v", args, tt.wantArgs)
+			}
+		})
 	}
 }

--- a/jone.go
+++ b/jone.go
@@ -39,6 +39,21 @@ type Column = schema.Column
 //	})
 type WhereGroup = query.WhereGroup
 
+// SelectBuilder builds SELECT queries (re-exported from query package).
+type SelectBuilder = query.SelectBuilder
+
+// Select starts a standalone SELECT builder, mainly for use as an EXISTS
+// subquery or, named via As(), as a derived table:
+//
+//	db.Select("*").From("users").
+//	    WhereExists(jone.Select("1").From("orders").WhereRaw("orders.user_id = users.id"))
+//
+//	sub := jone.Select("user_id").From("orders").GroupBy("user_id").As("t")
+//	db.Select("*").From(sub).Exec()
+//
+// To run queries, use db.Select() on a connected instance instead.
+var Select = query.Select
+
 // Core types (re-exported from types package)
 type CoreTable = types.Table
 type CoreColumn = types.Column

--- a/query/builder.go
+++ b/query/builder.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/Grandbusta/jone/dialect"
+	"github.com/Grandbusta/jone/types"
 )
 
 // Builder is the main query builder interface.
@@ -59,9 +60,38 @@ func (g *WhereGroup) OrWhere(args ...any) *WhereGroup {
 	return g
 }
 
+// WhereNot adds a negated condition: WhereNot(column, value),
+// WhereNot(column, operator, value), or WhereNot(func) for NOT (...).
+func (g *WhereGroup) WhereNot(args ...any) *WhereGroup {
+	cond, err := parseWhereNot(false, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// OrWhereNot is like WhereNot but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNot(args ...any) *WhereGroup {
+	cond, err := parseWhereNot(true, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
 // WhereIn adds an IN condition. Accepts variadic values or a single slice.
 func (g *WhereGroup) WhereIn(column string, values ...any) *WhereGroup {
 	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return g
+}
+
+// OrWhereIn is like WhereIn but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereIn(column string, values ...any) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondIn, Or: true, Column: column, Values: inValues(values)})
 	return g
 }
 
@@ -71,15 +101,33 @@ func (g *WhereGroup) WhereNotIn(column string, values ...any) *WhereGroup {
 	return g
 }
 
+// OrWhereNotIn is like WhereNotIn but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNotIn(column string, values ...any) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondIn, Or: true, Not: true, Column: column, Values: inValues(values)})
+	return g
+}
+
 // WhereNull adds an IS NULL condition.
 func (g *WhereGroup) WhereNull(column string) *WhereGroup {
 	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Column: column})
 	return g
 }
 
+// OrWhereNull is like WhereNull but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNull(column string) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Or: true, Column: column})
+	return g
+}
+
 // WhereNotNull adds an IS NOT NULL condition.
 func (g *WhereGroup) WhereNotNull(column string) *WhereGroup {
 	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return g
+}
+
+// OrWhereNotNull is like WhereNotNull but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNotNull(column string) *WhereGroup {
+	g.conds = append(g.conds, dialect.Cond{Kind: dialect.CondNull, Or: true, Not: true, Column: column})
 	return g
 }
 
@@ -91,6 +139,113 @@ func (g *WhereGroup) WhereRaw(raw string, args ...any) *WhereGroup {
 		return g
 	}
 	g.conds = append(g.conds, cond)
+	return g
+}
+
+// OrWhereRaw is like WhereRaw but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereRaw(raw string, args ...any) *WhereGroup {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	cond.Or = true
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// WhereBetween adds a BETWEEN condition: "col" BETWEEN low AND high.
+func (g *WhereGroup) WhereBetween(column string, low, high any) *WhereGroup {
+	g.conds = append(g.conds, betweenCond(false, false, column, low, high))
+	return g
+}
+
+// OrWhereBetween is like WhereBetween but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereBetween(column string, low, high any) *WhereGroup {
+	g.conds = append(g.conds, betweenCond(true, false, column, low, high))
+	return g
+}
+
+// WhereNotBetween adds a NOT BETWEEN condition.
+func (g *WhereGroup) WhereNotBetween(column string, low, high any) *WhereGroup {
+	g.conds = append(g.conds, betweenCond(false, true, column, low, high))
+	return g
+}
+
+// OrWhereNotBetween is like WhereNotBetween but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNotBetween(column string, low, high any) *WhereGroup {
+	g.conds = append(g.conds, betweenCond(true, true, column, low, high))
+	return g
+}
+
+// WhereExists adds an EXISTS (subquery) condition. The subquery is either a
+// *SelectBuilder or a raw SQL string with ? placeholders bound to args.
+func (g *WhereGroup) WhereExists(subquery any, args ...any) *WhereGroup {
+	cond, err := parseExists(false, false, subquery, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// OrWhereExists is like WhereExists but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereExists(subquery any, args ...any) *WhereGroup {
+	cond, err := parseExists(true, false, subquery, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// WhereNotExists adds a NOT EXISTS (subquery) condition.
+func (g *WhereGroup) WhereNotExists(subquery any, args ...any) *WhereGroup {
+	cond, err := parseExists(false, true, subquery, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// OrWhereNotExists is like WhereNotExists but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereNotExists(subquery any, args ...any) *WhereGroup {
+	cond, err := parseExists(true, true, subquery, args)
+	if err != nil {
+		g.setErr(err)
+		return g
+	}
+	g.conds = append(g.conds, cond)
+	return g
+}
+
+// WhereLike adds a case-sensitive pattern match: LIKE on PostgreSQL,
+// LIKE BINARY on MySQL.
+func (g *WhereGroup) WhereLike(column string, pattern any) *WhereGroup {
+	g.conds = append(g.conds, likeCond(false, false, column, pattern))
+	return g
+}
+
+// OrWhereLike is like WhereLike but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereLike(column string, pattern any) *WhereGroup {
+	g.conds = append(g.conds, likeCond(true, false, column, pattern))
+	return g
+}
+
+// WhereILike adds a case-insensitive pattern match: ILIKE on PostgreSQL,
+// LIKE on MySQL (whose default collation is case-insensitive).
+func (g *WhereGroup) WhereILike(column string, pattern any) *WhereGroup {
+	g.conds = append(g.conds, likeCond(false, true, column, pattern))
+	return g
+}
+
+// OrWhereILike is like WhereILike but joins with OR instead of AND.
+func (g *WhereGroup) OrWhereILike(column string, pattern any) *WhereGroup {
+	g.conds = append(g.conds, likeCond(true, true, column, pattern))
 	return g
 }
 
@@ -130,6 +285,17 @@ func parseWhere(or bool, args []any) (dialect.Cond, error) {
 	}
 }
 
+// parseWhereNot is parseWhere with the condition negated: NOT "col" = $1 for
+// the comparison forms, NOT (...) for the group form.
+func parseWhereNot(or bool, args []any) (dialect.Cond, error) {
+	cond, err := parseWhere(or, args)
+	if err != nil {
+		return cond, err
+	}
+	cond.Not = true
+	return cond, nil
+}
+
 // inValues normalizes WhereIn's variadic input: a single slice argument
 // (e.g. []string{"a", "b"}) is expanded element-by-element.
 func inValues(values []any) []any {
@@ -153,6 +319,43 @@ func parseWhereRaw(raw string, args []any) (dialect.Cond, error) {
 		return dialect.Cond{}, fmt.Errorf("WhereRaw has %d placeholders but %d args", n, len(args))
 	}
 	return dialect.Cond{Kind: dialect.CondRaw, Raw: raw, Values: args}, nil
+}
+
+// betweenCond builds a [NOT] BETWEEN condition.
+func betweenCond(or, not bool, column string, low, high any) dialect.Cond {
+	return dialect.Cond{Kind: dialect.CondBetween, Or: or, Not: not, Column: column, Values: []any{low, high}}
+}
+
+// likeCond builds a LIKE pattern-match condition. insensitive selects the
+// dialect's case-insensitive operator at compile time.
+func likeCond(or, insensitive bool, column string, pattern any) dialect.Cond {
+	return dialect.Cond{Kind: dialect.CondLike, Or: or, Insensitive: insensitive, Column: column, Value: pattern}
+}
+
+// parseExists builds an EXISTS condition from either a *SelectBuilder
+// subquery or a raw SQL string with ? placeholders bound to args.
+func parseExists(or, not bool, subquery any, args []any) (dialect.Cond, error) {
+	switch sq := subquery.(type) {
+	case *SelectBuilder:
+		if len(args) > 0 {
+			return dialect.Cond{}, fmt.Errorf("WhereExists args are only used with a raw SQL subquery, got %d args with a *SelectBuilder", len(args))
+		}
+		if sq.err != nil {
+			return dialect.Cond{}, sq.err
+		}
+		if sq.table == "" && sq.fromSub == nil {
+			return dialect.Cond{}, fmt.Errorf("WhereExists subquery has no table: call From() on it")
+		}
+		sub := sq.subSelect()
+		return dialect.Cond{Kind: dialect.CondExists, Or: or, Not: not, Sub: &sub}, nil
+	case string:
+		if n := strings.Count(sq, "?"); n != len(args) {
+			return dialect.Cond{}, fmt.Errorf("WhereExists subquery has %d placeholders but %d args", n, len(args))
+		}
+		return dialect.Cond{Kind: dialect.CondExists, Or: or, Not: not, Raw: sq, Values: args}, nil
+	default:
+		return dialect.Cond{}, fmt.Errorf("WhereExists expects a *SelectBuilder or a raw SQL string, got %T", subquery)
+	}
 }
 
 // scanRowMaps drains rows into maps keyed by column name.
@@ -210,15 +413,44 @@ func checkReturning(d dialect.Dialect, cols []string) error {
 
 // SelectBuilder builds SELECT queries.
 type SelectBuilder struct {
-	table   string
-	columns []string
-	where   []dialect.Cond
-	orderBy []dialect.OrderClause
-	limit   *int
-	offset  *int
-	dialect dialect.Dialect
-	execer  Execer
-	err     error
+	table      string
+	fromSub    *SelectBuilder // derived-table FROM; wins over table
+	alias      string         // name for this query when nested via From
+	columns    []string
+	distinct   bool
+	distinctOn []string
+	where      []dialect.Cond
+	groupBy    []dialect.GroupClause
+	having     []dialect.Cond
+	orderBy    []dialect.OrderClause
+	limit      *int
+	offset     *int
+	dialect    dialect.Dialect
+	execer     Execer
+	err        error
+}
+
+// subSelect gathers the builder's state into the neutral dialect form used
+// both for compilation and as an EXISTS subquery.
+func (s *SelectBuilder) subSelect() dialect.SubSelect {
+	sub := dialect.SubSelect{
+		Table:      s.table,
+		Columns:    s.columns,
+		Distinct:   s.distinct,
+		DistinctOn: s.distinctOn,
+		Wheres:     s.where,
+		GroupBys:   s.groupBy,
+		Havings:    s.having,
+		OrderBys:   s.orderBy,
+		Limit:      s.limit,
+		Offset:     s.offset,
+	}
+	if s.fromSub != nil {
+		inner := s.fromSub.subSelect()
+		sub.FromSub = &inner
+		sub.FromAlias = s.fromSub.alias
+	}
+	return sub
 }
 
 // NewSelectBuilder creates a dialect-aware SelectBuilder (used by Schema).
@@ -231,9 +463,38 @@ func Select(columns ...string) *SelectBuilder {
 	return &SelectBuilder{columns: columns}
 }
 
-// From sets the table to select from.
-func (s *SelectBuilder) From(table string) *SelectBuilder {
-	s.table = table
+// From sets the source to select from: a table name string, or a
+// *SelectBuilder used as a derived table — the subquery must be named with
+// As() first, e.g. From(jone.Select("user_id").From("orders").As("t")).
+func (s *SelectBuilder) From(table any) *SelectBuilder {
+	switch t := table.(type) {
+	case string:
+		s.table = t
+	case *SelectBuilder:
+		if t.err != nil {
+			s.setErr(t.err)
+			return s
+		}
+		if t.table == "" && t.fromSub == nil {
+			s.setErr(fmt.Errorf("From subquery has no table: call From() on it"))
+			return s
+		}
+		if t.alias == "" {
+			s.setErr(fmt.Errorf("From subquery requires an alias: call As() on it"))
+			return s
+		}
+		s.fromSub = t
+	default:
+		s.setErr(fmt.Errorf("From expects a table name string or a *SelectBuilder subquery, got %T", table))
+	}
+	return s
+}
+
+// As names this query for use as a derived table in an outer From().
+// The alias is required by both PostgreSQL and MySQL; it has no effect when
+// the query is executed directly.
+func (s *SelectBuilder) As(alias string) *SelectBuilder {
+	s.alias = alias
 	return s
 }
 
@@ -267,10 +528,39 @@ func (s *SelectBuilder) OrWhere(args ...any) *SelectBuilder {
 	return s
 }
 
+// WhereNot adds a negated condition: WhereNot(column, value),
+// WhereNot(column, operator, value), or WhereNot(func) for NOT (...).
+func (s *SelectBuilder) WhereNot(args ...any) *SelectBuilder {
+	cond, err := parseWhereNot(false, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// OrWhereNot is like WhereNot but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNot(args ...any) *SelectBuilder {
+	cond, err := parseWhereNot(true, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
 // WhereIn adds an IN condition. Accepts variadic values or a single slice:
 // WhereIn("status", "active", "pending") or WhereIn("status", []string{...}).
 func (s *SelectBuilder) WhereIn(column string, values ...any) *SelectBuilder {
 	s.where = append(s.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return s
+}
+
+// OrWhereIn is like WhereIn but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereIn(column string, values ...any) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Column: column, Values: inValues(values)})
 	return s
 }
 
@@ -280,15 +570,33 @@ func (s *SelectBuilder) WhereNotIn(column string, values ...any) *SelectBuilder 
 	return s
 }
 
+// OrWhereNotIn is like WhereNotIn but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNotIn(column string, values ...any) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Not: true, Column: column, Values: inValues(values)})
+	return s
+}
+
 // WhereNull adds an IS NULL condition.
 func (s *SelectBuilder) WhereNull(column string) *SelectBuilder {
 	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
 	return s
 }
 
+// OrWhereNull is like WhereNull but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNull(column string) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Column: column})
+	return s
+}
+
 // WhereNotNull adds an IS NOT NULL condition.
 func (s *SelectBuilder) WhereNotNull(column string) *SelectBuilder {
 	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return s
+}
+
+// OrWhereNotNull is like WhereNotNull but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNotNull(column string) *SelectBuilder {
+	s.where = append(s.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Not: true, Column: column})
 	return s
 }
 
@@ -301,6 +609,113 @@ func (s *SelectBuilder) WhereRaw(raw string, args ...any) *SelectBuilder {
 		return s
 	}
 	s.where = append(s.where, cond)
+	return s
+}
+
+// OrWhereRaw is like WhereRaw but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereRaw(raw string, args ...any) *SelectBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	cond.Or = true
+	s.where = append(s.where, cond)
+	return s
+}
+
+// WhereBetween adds a BETWEEN condition: "col" BETWEEN low AND high.
+func (s *SelectBuilder) WhereBetween(column string, low, high any) *SelectBuilder {
+	s.where = append(s.where, betweenCond(false, false, column, low, high))
+	return s
+}
+
+// OrWhereBetween is like WhereBetween but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereBetween(column string, low, high any) *SelectBuilder {
+	s.where = append(s.where, betweenCond(true, false, column, low, high))
+	return s
+}
+
+// WhereNotBetween adds a NOT BETWEEN condition.
+func (s *SelectBuilder) WhereNotBetween(column string, low, high any) *SelectBuilder {
+	s.where = append(s.where, betweenCond(false, true, column, low, high))
+	return s
+}
+
+// OrWhereNotBetween is like WhereNotBetween but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNotBetween(column string, low, high any) *SelectBuilder {
+	s.where = append(s.where, betweenCond(true, true, column, low, high))
+	return s
+}
+
+// WhereExists adds an EXISTS (subquery) condition. The subquery is either a
+// *SelectBuilder or a raw SQL string with ? placeholders bound to args.
+func (s *SelectBuilder) WhereExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(false, false, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// OrWhereExists is like WhereExists but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(true, false, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// WhereNotExists adds a NOT EXISTS (subquery) condition.
+func (s *SelectBuilder) WhereNotExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(false, true, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// OrWhereNotExists is like WhereNotExists but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereNotExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(true, true, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.where = append(s.where, cond)
+	return s
+}
+
+// WhereLike adds a case-sensitive pattern match: LIKE on PostgreSQL,
+// LIKE BINARY on MySQL.
+func (s *SelectBuilder) WhereLike(column string, pattern any) *SelectBuilder {
+	s.where = append(s.where, likeCond(false, false, column, pattern))
+	return s
+}
+
+// OrWhereLike is like WhereLike but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereLike(column string, pattern any) *SelectBuilder {
+	s.where = append(s.where, likeCond(true, false, column, pattern))
+	return s
+}
+
+// WhereILike adds a case-insensitive pattern match: ILIKE on PostgreSQL,
+// LIKE on MySQL (whose default collation is case-insensitive).
+func (s *SelectBuilder) WhereILike(column string, pattern any) *SelectBuilder {
+	s.where = append(s.where, likeCond(false, true, column, pattern))
+	return s
+}
+
+// OrWhereILike is like WhereILike but joins with OR instead of AND.
+func (s *SelectBuilder) OrWhereILike(column string, pattern any) *SelectBuilder {
+	s.where = append(s.where, likeCond(true, true, column, pattern))
 	return s
 }
 
@@ -334,6 +749,135 @@ func (s *SelectBuilder) OrderByRaw(raw string) *SelectBuilder {
 	return s
 }
 
+// Distinct makes the query SELECT DISTINCT. Columns are optional; any given
+// are appended to the select list: Distinct("city", "state") selects
+// distinct city/state pairs.
+func (s *SelectBuilder) Distinct(columns ...string) *SelectBuilder {
+	s.distinct = true
+	s.columns = append(s.columns, columns...)
+	return s
+}
+
+// DistinctOn makes the query SELECT DISTINCT ON (columns...), keeping the
+// first row of each set of rows sharing the given columns' values (order the
+// query so the row you want comes first). PostgreSQL only.
+func (s *SelectBuilder) DistinctOn(columns ...string) *SelectBuilder {
+	if len(columns) == 0 {
+		s.setErr(fmt.Errorf("DistinctOn requires at least one column"))
+		return s
+	}
+	if s.dialect != nil && !s.dialect.SupportsDistinctOn() {
+		s.setErr(fmt.Errorf("DISTINCT ON is not supported by %s", s.dialect.Name()))
+		return s
+	}
+	s.distinctOn = append(s.distinctOn, columns...)
+	return s
+}
+
+// GroupBy adds columns to the GROUP BY clause. Columns are quoted; for
+// expressions use GroupByRaw.
+func (s *SelectBuilder) GroupBy(columns ...string) *SelectBuilder {
+	for _, c := range columns {
+		s.groupBy = append(s.groupBy, dialect.GroupClause{Column: c})
+	}
+	return s
+}
+
+// GroupByRaw adds a raw GROUP BY expression used verbatim,
+// e.g. GroupByRaw("date_trunc('day', created_at)").
+func (s *SelectBuilder) GroupByRaw(raw string) *SelectBuilder {
+	s.groupBy = append(s.groupBy, dialect.GroupClause{Raw: raw})
+	return s
+}
+
+// Having adds a condition filtering grouped rows, using the same argument
+// forms as Where: Having(column, value), Having(column, operator, value), or
+// Having(func(g *jone.WhereGroup) {...}) for a parenthesized group. Usually
+// paired with GroupBy and an aggregate, e.g. Having("count", ">", 5).
+func (s *SelectBuilder) Having(args ...any) *SelectBuilder {
+	cond, err := parseWhere(false, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.having = append(s.having, cond)
+	return s
+}
+
+// HavingRaw adds a raw HAVING condition with ? placeholders bound to args,
+// e.g. HavingRaw("COUNT(*) > ?", 5).
+func (s *SelectBuilder) HavingRaw(raw string, args ...any) *SelectBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.having = append(s.having, cond)
+	return s
+}
+
+// HavingIn adds an IN condition to the HAVING clause. Accepts variadic
+// values or a single slice.
+func (s *SelectBuilder) HavingIn(column string, values ...any) *SelectBuilder {
+	s.having = append(s.having, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return s
+}
+
+// HavingNotIn adds a NOT IN condition to the HAVING clause.
+func (s *SelectBuilder) HavingNotIn(column string, values ...any) *SelectBuilder {
+	s.having = append(s.having, dialect.Cond{Kind: dialect.CondIn, Not: true, Column: column, Values: inValues(values)})
+	return s
+}
+
+// HavingNull adds an IS NULL condition to the HAVING clause.
+func (s *SelectBuilder) HavingNull(column string) *SelectBuilder {
+	s.having = append(s.having, dialect.Cond{Kind: dialect.CondNull, Column: column})
+	return s
+}
+
+// HavingNotNull adds an IS NOT NULL condition to the HAVING clause.
+func (s *SelectBuilder) HavingNotNull(column string) *SelectBuilder {
+	s.having = append(s.having, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return s
+}
+
+// HavingBetween adds a BETWEEN condition to the HAVING clause:
+// "col" BETWEEN low AND high.
+func (s *SelectBuilder) HavingBetween(column string, low, high any) *SelectBuilder {
+	s.having = append(s.having, betweenCond(false, false, column, low, high))
+	return s
+}
+
+// HavingNotBetween adds a NOT BETWEEN condition to the HAVING clause.
+func (s *SelectBuilder) HavingNotBetween(column string, low, high any) *SelectBuilder {
+	s.having = append(s.having, betweenCond(false, true, column, low, high))
+	return s
+}
+
+// HavingExists adds an EXISTS (subquery) condition to the HAVING clause. The
+// subquery is either a *SelectBuilder or a raw SQL string with ? placeholders
+// bound to args.
+func (s *SelectBuilder) HavingExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(false, false, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.having = append(s.having, cond)
+	return s
+}
+
+// HavingNotExists adds a NOT EXISTS (subquery) condition to the HAVING clause.
+func (s *SelectBuilder) HavingNotExists(subquery any, args ...any) *SelectBuilder {
+	cond, err := parseExists(false, true, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.having = append(s.having, cond)
+	return s
+}
+
 // Limit sets the LIMIT clause.
 func (s *SelectBuilder) Limit(n int) *SelectBuilder {
 	s.limit = &n
@@ -351,7 +895,7 @@ func (s *SelectBuilder) ToSQL() (string, []any) {
 	if s.dialect == nil {
 		return "", nil
 	}
-	return s.dialect.SelectSQL(s.table, s.columns, s.where, s.orderBy, s.limit, s.offset)
+	return s.dialect.SelectSQL(s.subSelect())
 }
 
 // Exec executes the SELECT query and returns the result rows.
@@ -362,7 +906,7 @@ func (s *SelectBuilder) Exec() (*sql.Rows, error) {
 	if s.execer == nil {
 		return nil, fmt.Errorf("no database connection")
 	}
-	if s.table == "" {
+	if s.table == "" && s.fromSub == nil {
 		return nil, fmt.Errorf("no table specified: call From() before Exec()")
 	}
 	sqlStr, args := s.ToSQL()
@@ -392,6 +936,92 @@ func (s *SelectBuilder) First() (map[string]any, error) {
 	return maps[0], nil
 }
 
+// All executes the query and returns every matching row as a map keyed by
+// column name. []byte column values are converted to string; no rows yields
+// an empty result, not an error.
+func (s *SelectBuilder) All() ([]map[string]any, error) {
+	rows, err := s.Exec()
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanRowMaps(rows)
+}
+
+// aggregate compiles and runs a single-value aggregate query, scanning the
+// result into dest. WHERE conditions apply; ORDER BY, LIMIT and OFFSET do not.
+func (s *SelectBuilder) aggregate(fn, column string, dest any) error {
+	if s.err != nil {
+		return s.err
+	}
+	if s.execer == nil {
+		return fmt.Errorf("no database connection")
+	}
+	if s.fromSub != nil {
+		return fmt.Errorf("%s over a From() subquery is not supported", fn)
+	}
+	if s.table == "" {
+		return fmt.Errorf("no table specified: call From() before %s()", fn)
+	}
+	if column == "" && fn != "COUNT" {
+		return fmt.Errorf("%s requires a column", fn)
+	}
+	sqlStr, args := s.dialect.AggregateSQL(s.table, fn, column, s.where)
+	return s.execer.QueryRow(sqlStr, args...).Scan(dest)
+}
+
+// aggregateFloat runs a numeric aggregate, returning 0 when no rows match
+// (the database returns NULL).
+func (s *SelectBuilder) aggregateFloat(fn, column string) (float64, error) {
+	var v sql.NullFloat64
+	if err := s.aggregate(fn, column, &v); err != nil {
+		return 0, err
+	}
+	return v.Float64, nil
+}
+
+// aggregateAny runs an aggregate whose type depends on the column, returning
+// nil when no rows match. []byte values are converted to string.
+func (s *SelectBuilder) aggregateAny(fn, column string) (any, error) {
+	var v any
+	if err := s.aggregate(fn, column, &v); err != nil {
+		return nil, err
+	}
+	if b, ok := v.([]byte); ok {
+		return string(b), nil
+	}
+	return v, nil
+}
+
+// Count executes SELECT COUNT(*) with the builder's WHERE conditions.
+func (s *SelectBuilder) Count() (int64, error) {
+	var n int64
+	if err := s.aggregate("COUNT", "*", &n); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// Sum executes SELECT SUM(column). Returns 0 when no rows match.
+func (s *SelectBuilder) Sum(column string) (float64, error) {
+	return s.aggregateFloat("SUM", column)
+}
+
+// Avg executes SELECT AVG(column). Returns 0 when no rows match.
+func (s *SelectBuilder) Avg(column string) (float64, error) {
+	return s.aggregateFloat("AVG", column)
+}
+
+// Min executes SELECT MIN(column). Returns nil when no rows match.
+func (s *SelectBuilder) Min(column string) (any, error) {
+	return s.aggregateAny("MIN", column)
+}
+
+// Max executes SELECT MAX(column). Returns nil when no rows match.
+func (s *SelectBuilder) Max(column string) (any, error) {
+	return s.aggregateAny("MAX", column)
+}
+
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {
 	table   string
@@ -403,18 +1033,88 @@ type UpdateBuilder struct {
 }
 
 // NewUpdateBuilder creates a dialect-aware UpdateBuilder (used by Schema).
-func NewUpdateBuilder(table string, d dialect.Dialect, execer Execer, err error) *UpdateBuilder {
-	return &UpdateBuilder{table: table, set: make(map[string]any), dialect: d, execer: execer, err: err}
+// args carry the update data in the forms accepted by Update.
+func NewUpdateBuilder(table string, args []any, d dialect.Dialect, execer Execer, err error) *UpdateBuilder {
+	u := &UpdateBuilder{table: table, dialect: d, execer: execer, err: err}
+	set, dataErr := parseUpdateData(args)
+	if dataErr != nil {
+		u.setErr(dataErr)
+	}
+	u.set = set
+	return u
 }
 
-// Update starts building an UPDATE query.
-func Update(table string) *UpdateBuilder {
-	return &UpdateBuilder{table: table, set: make(map[string]any)}
+// Update starts building an UPDATE query. The data to set is passed directly:
+// Update(table, map) for a map of columns, Update(table, struct) using db
+// tags with snake_case fallback, or Update(table, column, value) for a single
+// pair. The bare Update(table) form is valid when only Increment/Decrement
+// follow.
+func Update(table string, args ...any) *UpdateBuilder {
+	return NewUpdateBuilder(table, args, nil, nil, nil)
 }
 
-// Set adds a column=value pair to update.
-func (u *UpdateBuilder) Set(column string, value any) *UpdateBuilder {
-	u.set[column] = value
+// parseUpdateData normalizes Update's variadic data argument into a set map.
+// The map is always freshly allocated so later Increment/Decrement calls
+// never mutate a caller-supplied map.
+func parseUpdateData(args []any) (map[string]any, error) {
+	set := make(map[string]any)
+	switch len(args) {
+	case 0:
+		return set, nil
+	case 1:
+		switch data := args[0].(type) {
+		case map[string]any:
+			for k, v := range data {
+				set[k] = v
+			}
+			return set, nil
+		default:
+			rv := reflect.ValueOf(args[0])
+			if rv.Kind() == reflect.Ptr {
+				rv = rv.Elem()
+			}
+			if rv.Kind() != reflect.Struct {
+				return set, fmt.Errorf("Update expects map[string]any, a struct, or (column, value), got %T", args[0])
+			}
+			m, err := structToMap(args[0])
+			if err != nil {
+				return set, err
+			}
+			return m, nil
+		}
+	case 2:
+		col, ok := args[0].(string)
+		if !ok {
+			return set, fmt.Errorf("Update column must be a string, got %T", args[0])
+		}
+		set[col] = args[1]
+		return set, nil
+	default:
+		return set, fmt.Errorf("Update expects (table, data), (table, column, value), or (table), got %d data args", len(args))
+	}
+}
+
+// Increment sets column = column + amount. The amount defaults to 1.
+func (u *UpdateBuilder) Increment(column string, amount ...int) *UpdateBuilder {
+	return u.step(column, "+", amount)
+}
+
+// Decrement sets column = column - amount. The amount defaults to 1.
+func (u *UpdateBuilder) Decrement(column string, amount ...int) *UpdateBuilder {
+	return u.step(column, "-", amount)
+}
+
+// step records an increment/decrement as a raw set expression.
+func (u *UpdateBuilder) step(column, op string, amount []int) *UpdateBuilder {
+	if u.dialect == nil {
+		u.setErr(fmt.Errorf("no dialect available for Increment/Decrement"))
+		return u
+	}
+	n := 1
+	if len(amount) > 0 {
+		n = amount[0]
+	}
+	u.set[column] = types.RawExpr{Expr: fmt.Sprintf("%s %s %d", u.dialect.QuoteIdentifier(column), op, n)}
 	return u
 }
 
@@ -448,9 +1148,38 @@ func (u *UpdateBuilder) OrWhere(args ...any) *UpdateBuilder {
 	return u
 }
 
+// WhereNot adds a negated condition: WhereNot(column, value),
+// WhereNot(column, operator, value), or WhereNot(func) for NOT (...).
+func (u *UpdateBuilder) WhereNot(args ...any) *UpdateBuilder {
+	cond, err := parseWhereNot(false, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// OrWhereNot is like WhereNot but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNot(args ...any) *UpdateBuilder {
+	cond, err := parseWhereNot(true, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
 // WhereIn adds an IN condition. Accepts variadic values or a single slice.
 func (u *UpdateBuilder) WhereIn(column string, values ...any) *UpdateBuilder {
 	u.where = append(u.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return u
+}
+
+// OrWhereIn is like WhereIn but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereIn(column string, values ...any) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Column: column, Values: inValues(values)})
 	return u
 }
 
@@ -460,15 +1189,33 @@ func (u *UpdateBuilder) WhereNotIn(column string, values ...any) *UpdateBuilder 
 	return u
 }
 
+// OrWhereNotIn is like WhereNotIn but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNotIn(column string, values ...any) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Not: true, Column: column, Values: inValues(values)})
+	return u
+}
+
 // WhereNull adds an IS NULL condition.
 func (u *UpdateBuilder) WhereNull(column string) *UpdateBuilder {
 	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
 	return u
 }
 
+// OrWhereNull is like WhereNull but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNull(column string) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Column: column})
+	return u
+}
+
 // WhereNotNull adds an IS NOT NULL condition.
 func (u *UpdateBuilder) WhereNotNull(column string) *UpdateBuilder {
 	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return u
+}
+
+// OrWhereNotNull is like WhereNotNull but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNotNull(column string) *UpdateBuilder {
+	u.where = append(u.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Not: true, Column: column})
 	return u
 }
 
@@ -480,6 +1227,113 @@ func (u *UpdateBuilder) WhereRaw(raw string, args ...any) *UpdateBuilder {
 		return u
 	}
 	u.where = append(u.where, cond)
+	return u
+}
+
+// OrWhereRaw is like WhereRaw but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereRaw(raw string, args ...any) *UpdateBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	cond.Or = true
+	u.where = append(u.where, cond)
+	return u
+}
+
+// WhereBetween adds a BETWEEN condition: "col" BETWEEN low AND high.
+func (u *UpdateBuilder) WhereBetween(column string, low, high any) *UpdateBuilder {
+	u.where = append(u.where, betweenCond(false, false, column, low, high))
+	return u
+}
+
+// OrWhereBetween is like WhereBetween but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereBetween(column string, low, high any) *UpdateBuilder {
+	u.where = append(u.where, betweenCond(true, false, column, low, high))
+	return u
+}
+
+// WhereNotBetween adds a NOT BETWEEN condition.
+func (u *UpdateBuilder) WhereNotBetween(column string, low, high any) *UpdateBuilder {
+	u.where = append(u.where, betweenCond(false, true, column, low, high))
+	return u
+}
+
+// OrWhereNotBetween is like WhereNotBetween but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNotBetween(column string, low, high any) *UpdateBuilder {
+	u.where = append(u.where, betweenCond(true, true, column, low, high))
+	return u
+}
+
+// WhereExists adds an EXISTS (subquery) condition. The subquery is either a
+// *SelectBuilder or a raw SQL string with ? placeholders bound to args.
+func (u *UpdateBuilder) WhereExists(subquery any, args ...any) *UpdateBuilder {
+	cond, err := parseExists(false, false, subquery, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// OrWhereExists is like WhereExists but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereExists(subquery any, args ...any) *UpdateBuilder {
+	cond, err := parseExists(true, false, subquery, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// WhereNotExists adds a NOT EXISTS (subquery) condition.
+func (u *UpdateBuilder) WhereNotExists(subquery any, args ...any) *UpdateBuilder {
+	cond, err := parseExists(false, true, subquery, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// OrWhereNotExists is like WhereNotExists but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereNotExists(subquery any, args ...any) *UpdateBuilder {
+	cond, err := parseExists(true, true, subquery, args)
+	if err != nil {
+		u.setErr(err)
+		return u
+	}
+	u.where = append(u.where, cond)
+	return u
+}
+
+// WhereLike adds a case-sensitive pattern match: LIKE on PostgreSQL,
+// LIKE BINARY on MySQL.
+func (u *UpdateBuilder) WhereLike(column string, pattern any) *UpdateBuilder {
+	u.where = append(u.where, likeCond(false, false, column, pattern))
+	return u
+}
+
+// OrWhereLike is like WhereLike but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereLike(column string, pattern any) *UpdateBuilder {
+	u.where = append(u.where, likeCond(true, false, column, pattern))
+	return u
+}
+
+// WhereILike adds a case-insensitive pattern match: ILIKE on PostgreSQL,
+// LIKE on MySQL (whose default collation is case-insensitive).
+func (u *UpdateBuilder) WhereILike(column string, pattern any) *UpdateBuilder {
+	u.where = append(u.where, likeCond(false, true, column, pattern))
+	return u
+}
+
+// OrWhereILike is like WhereILike but joins with OR instead of AND.
+func (u *UpdateBuilder) OrWhereILike(column string, pattern any) *UpdateBuilder {
+	u.where = append(u.where, likeCond(true, true, column, pattern))
 	return u
 }
 
@@ -500,7 +1354,7 @@ func (u *UpdateBuilder) check() error {
 		return fmt.Errorf("no database connection")
 	}
 	if len(u.set) == 0 {
-		return fmt.Errorf("no values to update: call Set() before Exec()")
+		return fmt.Errorf("no values to update: pass data to Update() before Exec()")
 	}
 	return nil
 }
@@ -576,9 +1430,38 @@ func (d *DeleteBuilder) OrWhere(args ...any) *DeleteBuilder {
 	return d
 }
 
+// WhereNot adds a negated condition: WhereNot(column, value),
+// WhereNot(column, operator, value), or WhereNot(func) for NOT (...).
+func (d *DeleteBuilder) WhereNot(args ...any) *DeleteBuilder {
+	cond, err := parseWhereNot(false, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// OrWhereNot is like WhereNot but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNot(args ...any) *DeleteBuilder {
+	cond, err := parseWhereNot(true, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
 // WhereIn adds an IN condition. Accepts variadic values or a single slice.
 func (d *DeleteBuilder) WhereIn(column string, values ...any) *DeleteBuilder {
 	d.where = append(d.where, dialect.Cond{Kind: dialect.CondIn, Column: column, Values: inValues(values)})
+	return d
+}
+
+// OrWhereIn is like WhereIn but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereIn(column string, values ...any) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Column: column, Values: inValues(values)})
 	return d
 }
 
@@ -588,15 +1471,33 @@ func (d *DeleteBuilder) WhereNotIn(column string, values ...any) *DeleteBuilder 
 	return d
 }
 
+// OrWhereNotIn is like WhereNotIn but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNotIn(column string, values ...any) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondIn, Or: true, Not: true, Column: column, Values: inValues(values)})
+	return d
+}
+
 // WhereNull adds an IS NULL condition.
 func (d *DeleteBuilder) WhereNull(column string) *DeleteBuilder {
 	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Column: column})
 	return d
 }
 
+// OrWhereNull is like WhereNull but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNull(column string) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Column: column})
+	return d
+}
+
 // WhereNotNull adds an IS NOT NULL condition.
 func (d *DeleteBuilder) WhereNotNull(column string) *DeleteBuilder {
 	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Not: true, Column: column})
+	return d
+}
+
+// OrWhereNotNull is like WhereNotNull but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNotNull(column string) *DeleteBuilder {
+	d.where = append(d.where, dialect.Cond{Kind: dialect.CondNull, Or: true, Not: true, Column: column})
 	return d
 }
 
@@ -608,6 +1509,113 @@ func (d *DeleteBuilder) WhereRaw(raw string, args ...any) *DeleteBuilder {
 		return d
 	}
 	d.where = append(d.where, cond)
+	return d
+}
+
+// OrWhereRaw is like WhereRaw but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereRaw(raw string, args ...any) *DeleteBuilder {
+	cond, err := parseWhereRaw(raw, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	cond.Or = true
+	d.where = append(d.where, cond)
+	return d
+}
+
+// WhereBetween adds a BETWEEN condition: "col" BETWEEN low AND high.
+func (d *DeleteBuilder) WhereBetween(column string, low, high any) *DeleteBuilder {
+	d.where = append(d.where, betweenCond(false, false, column, low, high))
+	return d
+}
+
+// OrWhereBetween is like WhereBetween but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereBetween(column string, low, high any) *DeleteBuilder {
+	d.where = append(d.where, betweenCond(true, false, column, low, high))
+	return d
+}
+
+// WhereNotBetween adds a NOT BETWEEN condition.
+func (d *DeleteBuilder) WhereNotBetween(column string, low, high any) *DeleteBuilder {
+	d.where = append(d.where, betweenCond(false, true, column, low, high))
+	return d
+}
+
+// OrWhereNotBetween is like WhereNotBetween but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNotBetween(column string, low, high any) *DeleteBuilder {
+	d.where = append(d.where, betweenCond(true, true, column, low, high))
+	return d
+}
+
+// WhereExists adds an EXISTS (subquery) condition. The subquery is either a
+// *SelectBuilder or a raw SQL string with ? placeholders bound to args.
+func (d *DeleteBuilder) WhereExists(subquery any, args ...any) *DeleteBuilder {
+	cond, err := parseExists(false, false, subquery, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// OrWhereExists is like WhereExists but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereExists(subquery any, args ...any) *DeleteBuilder {
+	cond, err := parseExists(true, false, subquery, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// WhereNotExists adds a NOT EXISTS (subquery) condition.
+func (d *DeleteBuilder) WhereNotExists(subquery any, args ...any) *DeleteBuilder {
+	cond, err := parseExists(false, true, subquery, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// OrWhereNotExists is like WhereNotExists but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereNotExists(subquery any, args ...any) *DeleteBuilder {
+	cond, err := parseExists(true, true, subquery, args)
+	if err != nil {
+		d.setErr(err)
+		return d
+	}
+	d.where = append(d.where, cond)
+	return d
+}
+
+// WhereLike adds a case-sensitive pattern match: LIKE on PostgreSQL,
+// LIKE BINARY on MySQL.
+func (d *DeleteBuilder) WhereLike(column string, pattern any) *DeleteBuilder {
+	d.where = append(d.where, likeCond(false, false, column, pattern))
+	return d
+}
+
+// OrWhereLike is like WhereLike but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereLike(column string, pattern any) *DeleteBuilder {
+	d.where = append(d.where, likeCond(true, false, column, pattern))
+	return d
+}
+
+// WhereILike adds a case-insensitive pattern match: ILIKE on PostgreSQL,
+// LIKE on MySQL (whose default collation is case-insensitive).
+func (d *DeleteBuilder) WhereILike(column string, pattern any) *DeleteBuilder {
+	d.where = append(d.where, likeCond(false, true, column, pattern))
+	return d
+}
+
+// OrWhereILike is like WhereILike but joins with OR instead of AND.
+func (d *DeleteBuilder) OrWhereILike(column string, pattern any) *DeleteBuilder {
+	d.where = append(d.where, likeCond(true, true, column, pattern))
 	return d
 }
 

--- a/query/builder.go
+++ b/query/builder.go
@@ -419,6 +419,7 @@ type SelectBuilder struct {
 	columns    []string
 	distinct   bool
 	distinctOn []string
+	joins      []dialect.JoinClause
 	where      []dialect.Cond
 	groupBy    []dialect.GroupClause
 	having     []dialect.Cond
@@ -438,6 +439,7 @@ func (s *SelectBuilder) subSelect() dialect.SubSelect {
 		Columns:    s.columns,
 		Distinct:   s.distinct,
 		DistinctOn: s.distinctOn,
+		Joins:      s.joins,
 		Wheres:     s.where,
 		GroupBys:   s.groupBy,
 		Havings:    s.having,
@@ -487,6 +489,75 @@ func (s *SelectBuilder) From(table any) *SelectBuilder {
 	default:
 		s.setErr(fmt.Errorf("From expects a table name string or a *SelectBuilder subquery, got %T", table))
 	}
+	return s
+}
+
+// join appends a structured join clause, accepting the two ON forms.
+func (s *SelectBuilder) join(kind, table string, on []string) *SelectBuilder {
+	j := dialect.JoinClause{Kind: kind, Table: table, Op: "="}
+	switch len(on) {
+	case 2:
+		j.Left, j.Right = on[0], on[1]
+	case 3:
+		j.Left, j.Op, j.Right = on[0], on[1], on[2]
+	default:
+		s.setErr(fmt.Errorf("Join expects (table, left, right) or (table, left, op, right), got %d ON args", len(on)))
+		return s
+	}
+	s.joins = append(s.joins, j)
+	return s
+}
+
+// Join adds an INNER JOIN: Join(table, left, right) for an equality ON, or
+// Join(table, left, op, right) for other operators. Columns are qualified
+// identifiers ("users.id"); the table may use "orders as o" aliasing.
+func (s *SelectBuilder) Join(table string, on ...string) *SelectBuilder {
+	return s.join("INNER JOIN", table, on)
+}
+
+// LeftJoin is Join with a LEFT JOIN.
+func (s *SelectBuilder) LeftJoin(table string, on ...string) *SelectBuilder {
+	return s.join("LEFT JOIN", table, on)
+}
+
+// RightJoin is Join with a RIGHT JOIN.
+func (s *SelectBuilder) RightJoin(table string, on ...string) *SelectBuilder {
+	return s.join("RIGHT JOIN", table, on)
+}
+
+// LeftOuterJoin is Join with a LEFT OUTER JOIN (equivalent to LeftJoin).
+func (s *SelectBuilder) LeftOuterJoin(table string, on ...string) *SelectBuilder {
+	return s.join("LEFT OUTER JOIN", table, on)
+}
+
+// RightOuterJoin is Join with a RIGHT OUTER JOIN (equivalent to RightJoin).
+func (s *SelectBuilder) RightOuterJoin(table string, on ...string) *SelectBuilder {
+	return s.join("RIGHT OUTER JOIN", table, on)
+}
+
+// FullOuterJoin is Join with a FULL OUTER JOIN. PostgreSQL only.
+func (s *SelectBuilder) FullOuterJoin(table string, on ...string) *SelectBuilder {
+	if s.dialect != nil && !s.dialect.SupportsFullOuterJoin() {
+		s.setErr(fmt.Errorf("FULL OUTER JOIN is not supported by %s", s.dialect.Name()))
+		return s
+	}
+	return s.join("FULL OUTER JOIN", table, on)
+}
+
+// CrossJoin adds a CROSS JOIN (cartesian product) — no ON condition.
+func (s *SelectBuilder) CrossJoin(table string) *SelectBuilder {
+	s.joins = append(s.joins, dialect.JoinClause{Kind: "CROSS JOIN", Table: table})
+	return s
+}
+
+// JoinRaw adds a raw join fragment used verbatim, with ? placeholders bound
+// to args, e.g. JoinRaw("LEFT JOIN orders o ON o.user_id = users.id AND o.total > ?", 100).
+func (s *SelectBuilder) JoinRaw(raw string, args ...any) *SelectBuilder {
+	if n := strings.Count(raw, "?"); n != len(args) {
+		s.setErr(fmt.Errorf("JoinRaw has %d placeholders but %d args", n, len(args)))
+		return s
+	}
+	s.joins = append(s.joins, dialect.JoinClause{Raw: raw, Values: args})
 	return s
 }
 
@@ -1379,6 +1450,39 @@ func (u *UpdateBuilder) ExecReturning(columns ...string) ([]map[string]any, erro
 	}
 	sqlStr, args := u.dialect.UpdateSQL(u.table, u.set, u.where, columns)
 	return execReturning(u.execer, sqlStr, args)
+}
+
+// TruncateBuilder builds TRUNCATE TABLE statements.
+type TruncateBuilder struct {
+	table   string
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewTruncateBuilder creates a dialect-aware TruncateBuilder (used by Schema).
+func NewTruncateBuilder(table string, d dialect.Dialect, execer Execer, err error) *TruncateBuilder {
+	return &TruncateBuilder{table: table, dialect: d, execer: execer, err: err}
+}
+
+// ToSQL generates the TRUNCATE SQL.
+func (t *TruncateBuilder) ToSQL() (string, []any) {
+	if t.dialect == nil {
+		return "", nil
+	}
+	return t.dialect.TruncateSQL(t.table), nil
+}
+
+// Exec executes the TRUNCATE and returns the result.
+func (t *TruncateBuilder) Exec() (sql.Result, error) {
+	if t.err != nil {
+		return nil, t.err
+	}
+	if t.execer == nil {
+		return nil, fmt.Errorf("no database connection")
+	}
+	sqlStr, _ := t.ToSQL()
+	return t.execer.Exec(sqlStr)
 }
 
 // DeleteBuilder builds DELETE queries.

--- a/query/builder.go
+++ b/query/builder.go
@@ -332,30 +332,41 @@ func likeCond(or, insensitive bool, column string, pattern any) dialect.Cond {
 	return dialect.Cond{Kind: dialect.CondLike, Or: or, Insensitive: insensitive, Column: column, Value: pattern}
 }
 
-// parseExists builds an EXISTS condition from either a *SelectBuilder
-// subquery or a raw SQL string with ? placeholders bound to args.
-func parseExists(or, not bool, subquery any, args []any) (dialect.Cond, error) {
+// parseSubquery normalizes a subquery argument for name (used in error
+// messages): a *SelectBuilder yields sub, a raw SQL string with ?
+// placeholders bound to args yields raw+values.
+func parseSubquery(name string, subquery any, args []any) (sub *dialect.SubSelect, raw string, values []any, err error) {
 	switch sq := subquery.(type) {
 	case *SelectBuilder:
 		if len(args) > 0 {
-			return dialect.Cond{}, fmt.Errorf("WhereExists args are only used with a raw SQL subquery, got %d args with a *SelectBuilder", len(args))
+			return nil, "", nil, fmt.Errorf("%s args are only used with a raw SQL subquery, got %d args with a *SelectBuilder", name, len(args))
 		}
 		if sq.err != nil {
-			return dialect.Cond{}, sq.err
+			return nil, "", nil, sq.err
 		}
 		if sq.table == "" && sq.fromSub == nil {
-			return dialect.Cond{}, fmt.Errorf("WhereExists subquery has no table: call From() on it")
+			return nil, "", nil, fmt.Errorf("%s subquery has no table: call From() on it", name)
 		}
-		sub := sq.subSelect()
-		return dialect.Cond{Kind: dialect.CondExists, Or: or, Not: not, Sub: &sub}, nil
+		s := sq.subSelect()
+		return &s, "", nil, nil
 	case string:
 		if n := strings.Count(sq, "?"); n != len(args) {
-			return dialect.Cond{}, fmt.Errorf("WhereExists subquery has %d placeholders but %d args", n, len(args))
+			return nil, "", nil, fmt.Errorf("%s subquery has %d placeholders but %d args", name, n, len(args))
 		}
-		return dialect.Cond{Kind: dialect.CondExists, Or: or, Not: not, Raw: sq, Values: args}, nil
+		return nil, sq, args, nil
 	default:
-		return dialect.Cond{}, fmt.Errorf("WhereExists expects a *SelectBuilder or a raw SQL string, got %T", subquery)
+		return nil, "", nil, fmt.Errorf("%s expects a *SelectBuilder or a raw SQL string, got %T", name, subquery)
 	}
+}
+
+// parseExists builds an EXISTS condition from either a *SelectBuilder
+// subquery or a raw SQL string with ? placeholders bound to args.
+func parseExists(or, not bool, subquery any, args []any) (dialect.Cond, error) {
+	sub, raw, values, err := parseSubquery("WhereExists", subquery, args)
+	if err != nil {
+		return dialect.Cond{}, err
+	}
+	return dialect.Cond{Kind: dialect.CondExists, Or: or, Not: not, Sub: sub, Raw: raw, Values: values}, nil
 }
 
 // scanRowMaps drains rows into maps keyed by column name.
@@ -411,15 +422,30 @@ func checkReturning(d dialect.Dialect, cols []string) error {
 	return nil
 }
 
+// prefixSchema qualifies a table reference with a schema, relying on
+// dot-aware identifier quoting at compile time. Alias forms ("orders as o")
+// work unchanged since the prefix lands on the table part.
+func prefixSchema(schemaName, table string) string {
+	if schemaName == "" || table == "" {
+		return table
+	}
+	return schemaName + "." + table
+}
+
 // SelectBuilder builds SELECT queries.
 type SelectBuilder struct {
 	table      string
+	schemaName string
 	fromSub    *SelectBuilder // derived-table FROM; wins over table
 	alias      string         // name for this query when nested via From
 	columns    []string
 	distinct   bool
 	distinctOn []string
+	ctes       []dialect.CTE
 	joins      []dialect.JoinClause
+	unions     []dialect.UnionClause
+	lock       string // "FOR UPDATE" / "FOR SHARE"
+	lockMod    string // "SKIP LOCKED" / "NOWAIT"
 	where      []dialect.Cond
 	groupBy    []dialect.GroupClause
 	having     []dialect.Cond
@@ -434,12 +460,29 @@ type SelectBuilder struct {
 // subSelect gathers the builder's state into the neutral dialect form used
 // both for compilation and as an EXISTS subquery.
 func (s *SelectBuilder) subSelect() dialect.SubSelect {
+	lock := s.lock
+	if lock != "" && s.lockMod != "" {
+		lock += " " + s.lockMod
+	}
+	joins := s.joins
+	if s.schemaName != "" && len(joins) > 0 {
+		joins = make([]dialect.JoinClause, len(s.joins))
+		copy(joins, s.joins)
+		for i := range joins {
+			if joins[i].Raw == "" {
+				joins[i].Table = prefixSchema(s.schemaName, joins[i].Table)
+			}
+		}
+	}
 	sub := dialect.SubSelect{
-		Table:      s.table,
+		CTEs:       s.ctes,
+		Unions:     s.unions,
+		Lock:       lock,
+		Table:      prefixSchema(s.schemaName, s.table),
 		Columns:    s.columns,
 		Distinct:   s.distinct,
 		DistinctOn: s.distinctOn,
-		Joins:      s.joins,
+		Joins:      joins,
 		Wheres:     s.where,
 		GroupBys:   s.groupBy,
 		Havings:    s.having,
@@ -561,11 +604,106 @@ func (s *SelectBuilder) JoinRaw(raw string, args ...any) *SelectBuilder {
 	return s
 }
 
+// with appends a CTE clause in builder or raw form.
+func (s *SelectBuilder) with(name string, recursive bool, subquery any, args []any, method string) *SelectBuilder {
+	sub, raw, values, err := parseSubquery(method, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.ctes = append(s.ctes, dialect.CTE{Name: name, Recursive: recursive, Sub: sub, Raw: raw, Values: values})
+	return s
+}
+
+// With adds a WITH clause (common table expression) that the query can then
+// select from by name. The body is a *SelectBuilder or a raw SQL string with
+// ? placeholders bound to args:
+//
+//	db.Select("*").From("totals").
+//	    With("totals", jone.Select("user_id").From("orders").GroupBy("user_id"))
+func (s *SelectBuilder) With(name string, subquery any, args ...any) *SelectBuilder {
+	return s.with(name, false, subquery, args, "With")
+}
+
+// WithRecursive is With using WITH RECURSIVE, for CTEs that reference
+// themselves. RECURSIVE applies to the statement's whole CTE list.
+func (s *SelectBuilder) WithRecursive(name string, subquery any, args ...any) *SelectBuilder {
+	return s.with(name, true, subquery, args, "WithRecursive")
+}
+
+// union appends a UNION clause in builder or raw form.
+func (s *SelectBuilder) union(all bool, subquery any, args []any, method string) *SelectBuilder {
+	sub, raw, values, err := parseSubquery(method, subquery, args)
+	if err != nil {
+		s.setErr(err)
+		return s
+	}
+	s.unions = append(s.unions, dialect.UnionClause{All: all, Sub: sub, Raw: raw, Values: values})
+	return s
+}
+
+// Union combines this query with another via UNION (duplicates removed).
+// The other query is a *SelectBuilder or a raw SQL string with ?
+// placeholders bound to args. ORDER BY, LIMIT and OFFSET on this builder
+// apply to the combined result.
+func (s *SelectBuilder) Union(subquery any, args ...any) *SelectBuilder {
+	return s.union(false, subquery, args, "Union")
+}
+
+// UnionAll is Union keeping duplicates.
+func (s *SelectBuilder) UnionAll(subquery any, args ...any) *SelectBuilder {
+	return s.union(true, subquery, args, "UnionAll")
+}
+
+// ForUpdate locks the selected rows for update (SELECT ... FOR UPDATE).
+// Use inside a transaction.
+func (s *SelectBuilder) ForUpdate() *SelectBuilder {
+	s.lock = "FOR UPDATE"
+	return s
+}
+
+// ForShare takes a shared lock on the selected rows (SELECT ... FOR SHARE).
+// Use inside a transaction.
+func (s *SelectBuilder) ForShare() *SelectBuilder {
+	s.lock = "FOR SHARE"
+	return s
+}
+
+// SkipLocked skips rows that are already locked instead of waiting.
+// Call after ForUpdate or ForShare.
+func (s *SelectBuilder) SkipLocked() *SelectBuilder {
+	if s.lock == "" {
+		s.setErr(fmt.Errorf("SkipLocked requires ForUpdate or ForShare first"))
+		return s
+	}
+	s.lockMod = "SKIP LOCKED"
+	return s
+}
+
+// NoWait errors immediately if a selected row is already locked instead of
+// waiting. Call after ForUpdate or ForShare.
+func (s *SelectBuilder) NoWait() *SelectBuilder {
+	if s.lock == "" {
+		s.setErr(fmt.Errorf("NoWait requires ForUpdate or ForShare first"))
+		return s
+	}
+	s.lockMod = "NOWAIT"
+	return s
+}
+
 // As names this query for use as a derived table in an outer From().
 // The alias is required by both PostgreSQL and MySQL; it has no effect when
 // the query is executed directly.
 func (s *SelectBuilder) As(alias string) *SelectBuilder {
 	s.alias = alias
+	return s
+}
+
+// WithSchema qualifies the query's tables with a schema name: the FROM table
+// and structured join tables (JoinRaw fragments are used verbatim). Note this
+// also covers joins, unlike knex.
+func (s *SelectBuilder) WithSchema(name string) *SelectBuilder {
+	s.schemaName = name
 	return s
 }
 
@@ -1037,7 +1175,7 @@ func (s *SelectBuilder) aggregate(fn, column string, dest any) error {
 	if column == "" && fn != "COUNT" {
 		return fmt.Errorf("%s requires a column", fn)
 	}
-	sqlStr, args := s.dialect.AggregateSQL(s.table, fn, column, s.where)
+	sqlStr, args := s.dialect.AggregateSQL(prefixSchema(s.schemaName, s.table), fn, column, s.where)
 	return s.execer.QueryRow(sqlStr, args...).Scan(dest)
 }
 
@@ -1095,12 +1233,13 @@ func (s *SelectBuilder) Max(column string) (any, error) {
 
 // UpdateBuilder builds UPDATE queries.
 type UpdateBuilder struct {
-	table   string
-	set     map[string]any
-	where   []dialect.Cond
-	dialect dialect.Dialect
-	execer  Execer
-	err     error
+	table      string
+	schemaName string
+	set        map[string]any
+	where      []dialect.Cond
+	dialect    dialect.Dialect
+	execer     Execer
+	err        error
 }
 
 // NewUpdateBuilder creates a dialect-aware UpdateBuilder (used by Schema).
@@ -1186,6 +1325,12 @@ func (u *UpdateBuilder) step(column, op string, amount []int) *UpdateBuilder {
 		n = amount[0]
 	}
 	u.set[column] = types.RawExpr{Expr: fmt.Sprintf("%s %s %d", u.dialect.QuoteIdentifier(column), op, n)}
+	return u
+}
+
+// WithSchema qualifies the update's table with a schema name.
+func (u *UpdateBuilder) WithSchema(name string) *UpdateBuilder {
+	u.schemaName = name
 	return u
 }
 
@@ -1413,7 +1558,7 @@ func (u *UpdateBuilder) ToSQL() (string, []any) {
 	if u.dialect == nil {
 		return "", nil
 	}
-	return u.dialect.UpdateSQL(u.table, u.set, u.where, nil)
+	return u.dialect.UpdateSQL(prefixSchema(u.schemaName, u.table), u.set, u.where, nil)
 }
 
 // check validates the builder state before execution.
@@ -1448,16 +1593,17 @@ func (u *UpdateBuilder) ExecReturning(columns ...string) ([]map[string]any, erro
 	if err := checkReturning(u.dialect, columns); err != nil {
 		return nil, err
 	}
-	sqlStr, args := u.dialect.UpdateSQL(u.table, u.set, u.where, columns)
+	sqlStr, args := u.dialect.UpdateSQL(prefixSchema(u.schemaName, u.table), u.set, u.where, columns)
 	return execReturning(u.execer, sqlStr, args)
 }
 
 // TruncateBuilder builds TRUNCATE TABLE statements.
 type TruncateBuilder struct {
-	table   string
-	dialect dialect.Dialect
-	execer  Execer
-	err     error
+	table      string
+	schemaName string
+	dialect    dialect.Dialect
+	execer     Execer
+	err        error
 }
 
 // NewTruncateBuilder creates a dialect-aware TruncateBuilder (used by Schema).
@@ -1465,12 +1611,18 @@ func NewTruncateBuilder(table string, d dialect.Dialect, execer Execer, err erro
 	return &TruncateBuilder{table: table, dialect: d, execer: execer, err: err}
 }
 
+// WithSchema qualifies the truncated table with a schema name.
+func (t *TruncateBuilder) WithSchema(name string) *TruncateBuilder {
+	t.schemaName = name
+	return t
+}
+
 // ToSQL generates the TRUNCATE SQL.
 func (t *TruncateBuilder) ToSQL() (string, []any) {
 	if t.dialect == nil {
 		return "", nil
 	}
-	return t.dialect.TruncateSQL(t.table), nil
+	return t.dialect.TruncateSQL(prefixSchema(t.schemaName, t.table)), nil
 }
 
 // Exec executes the TRUNCATE and returns the result.
@@ -1487,11 +1639,12 @@ func (t *TruncateBuilder) Exec() (sql.Result, error) {
 
 // DeleteBuilder builds DELETE queries.
 type DeleteBuilder struct {
-	table   string
-	where   []dialect.Cond
-	dialect dialect.Dialect
-	execer  Execer
-	err     error
+	table      string
+	schemaName string
+	where      []dialect.Cond
+	dialect    dialect.Dialect
+	execer     Execer
+	err        error
 }
 
 // NewDeleteBuilder creates a dialect-aware DeleteBuilder (used by Schema).
@@ -1502,6 +1655,12 @@ func NewDeleteBuilder(table string, d dialect.Dialect, execer Execer, err error)
 // Delete starts building a DELETE query.
 func Delete(table string) *DeleteBuilder {
 	return &DeleteBuilder{table: table}
+}
+
+// WithSchema qualifies the delete's table with a schema name.
+func (d *DeleteBuilder) WithSchema(name string) *DeleteBuilder {
+	d.schemaName = name
+	return d
 }
 
 // setErr records a deferred error without masking an earlier one.
@@ -1728,7 +1887,7 @@ func (d *DeleteBuilder) ToSQL() (string, []any) {
 	if d.dialect == nil {
 		return "", nil
 	}
-	return d.dialect.DeleteSQL(d.table, d.where, nil)
+	return d.dialect.DeleteSQL(prefixSchema(d.schemaName, d.table), d.where, nil)
 }
 
 // check validates the builder state before execution.
@@ -1760,6 +1919,6 @@ func (d *DeleteBuilder) ExecReturning(columns ...string) ([]map[string]any, erro
 	if err := checkReturning(d.dialect, columns); err != nil {
 		return nil, err
 	}
-	sqlStr, args := d.dialect.DeleteSQL(d.table, d.where, columns)
+	sqlStr, args := d.dialect.DeleteSQL(prefixSchema(d.schemaName, d.table), d.where, columns)
 	return execReturning(d.execer, sqlStr, args)
 }

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -226,6 +226,39 @@ func TestDeleteExec_PassesArgs(t *testing.T) {
 	}
 }
 
+func TestTruncate_BothDialects(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	my := &dialect.MySQLDialect{}
+
+	sql, args := NewTruncateBuilder("users", pg, nil, nil).ToSQL()
+	if sql != `TRUNCATE TABLE "users";` || len(args) != 0 {
+		t.Errorf("SQL = %q, args = %v", sql, args)
+	}
+
+	sql, _ = NewTruncateBuilder("users", my, nil, nil).ToSQL()
+	if sql != "TRUNCATE TABLE `users`;" {
+		t.Errorf("SQL = %q", sql)
+	}
+}
+
+func TestTruncate_ExecAndErrors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	rec := &recordingExecer{}
+
+	_, err := NewTruncateBuilder("users", pg, rec, nil).Exec()
+	if err != nil {
+		t.Fatalf("Exec() error: %v", err)
+	}
+	if rec.query != `TRUNCATE TABLE "users";` {
+		t.Errorf("query = %q", rec.query)
+	}
+
+	_, err = NewTruncateBuilder("users", pg, nil, nil).Exec()
+	if err == nil || !strings.Contains(err.Error(), "no database connection") {
+		t.Errorf("expected no-connection error, got %v", err)
+	}
+}
+
 // --- First() tests using a minimal in-memory driver ---
 
 // stubDriver serves fixed columns/rows and records the last query.
@@ -1008,6 +1041,141 @@ func TestWhereExists_SubqueryCarriesGroupBy(t *testing.T) {
 	want := `SELECT * FROM "users" WHERE EXISTS (SELECT "user_id" FROM "orders" WHERE orders.user_id = users.id GROUP BY "user_id");`
 	if sql != want {
 		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+// --- Join tests ---
+
+func TestJoin_InnerWithAliasAndQualifiedColumns(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"users.name", "o.total"}, pg, nil, nil).
+		From("users").
+		Join("orders as o", "users.id", "o.user_id").
+		Where("o.total", ">", 100).
+		ToSQL()
+	want := `SELECT "users"."name", "o"."total" FROM "users" INNER JOIN "orders" AS "o" ON "users"."id" = "o"."user_id" WHERE "o"."total" > $1;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 100 {
+		t.Errorf("args = %v, want [100]", args)
+	}
+}
+
+func TestLeftJoin_OperatorForm_MySQL(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sql, _ := NewSelectBuilder([]string{"users.*"}, my, nil, nil).
+		From("users").
+		LeftJoin("profiles", "users.id", "=", "profiles.user_id").
+		ToSQL()
+	want := "SELECT `users`.* FROM `users` LEFT JOIN `profiles` ON `users`.`id` = `profiles`.`user_id`;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestRightJoin_And_SelfJoinAliases(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder([]string{"e.name", "m.name"}, pg, nil, nil).
+		From("employees as e").
+		RightJoin("employees as m", "e.manager_id", "m.id").
+		ToSQL()
+	want := `SELECT "e"."name", "m"."name" FROM "employees" AS "e" RIGHT JOIN "employees" AS "m" ON "e"."manager_id" = "m"."id";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestJoinRaw_ArgsNumberBeforeWhere(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		JoinRaw("LEFT JOIN orders o ON o.user_id = users.id AND o.total > ?", 100).
+		Where("users.active", true).
+		ToSQL()
+	want := `SELECT * FROM "users" LEFT JOIN orders o ON o.user_id = users.id AND o.total > $1 WHERE "users"."active" = $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != 100 || args[1] != true {
+		t.Errorf("args = %v, want [100 true]", args)
+	}
+}
+
+func TestJoin_OnDerivedTable(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sub := Select("user_id").From("orders").GroupBy("user_id").As("t")
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From(sub).
+		Join("users", "t.user_id", "users.id").
+		ToSQL()
+	want := `SELECT * FROM (SELECT "user_id" FROM "orders" GROUP BY "user_id") AS "t" INNER JOIN "users" ON "t"."user_id" = "users"."id";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestOuterJoinVariants(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		LeftOuterJoin("orders", "users.id", "orders.user_id").
+		RightOuterJoin("profiles", "users.id", "profiles.user_id").
+		FullOuterJoin("audits", "users.id", "!=", "audits.user_id").
+		ToSQL()
+	want := `SELECT * FROM "users" LEFT OUTER JOIN "orders" ON "users"."id" = "orders"."user_id" RIGHT OUTER JOIN "profiles" ON "users"."id" = "profiles"."user_id" FULL OUTER JOIN "audits" ON "users"."id" != "audits"."user_id";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestCrossJoin(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sql, args := NewSelectBuilder(nil, my, nil, nil).
+		From("sizes").
+		CrossJoin("colors as c").
+		ToSQL()
+	want := "SELECT * FROM `sizes` CROSS JOIN `colors` AS `c`;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("args = %v, want none", args)
+	}
+}
+
+func TestFullOuterJoin_MySQLUnsupported(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	_, err := NewSelectBuilder(nil, my, &recordingExecer{}, nil).
+		From("users").
+		FullOuterJoin("orders", "users.id", "orders.user_id").
+		Exec()
+	if err == nil || !strings.Contains(err.Error(), "FULL OUTER JOIN is not supported") {
+		t.Errorf("expected unsupported error, got %v", err)
+	}
+}
+
+func TestJoin_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Join("orders", "users.id").Exec()
+	if err == nil || !strings.Contains(err.Error(), "Join expects") {
+		t.Errorf("expected ON arity error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").JoinRaw("JOIN x ON a = ? AND b = ?", 1).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
 	}
 }
 

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -317,3 +317,949 @@ func TestFirst_NoRows(t *testing.T) {
 		t.Errorf("expected sql.ErrNoRows, got %v", err)
 	}
 }
+
+func TestAll_ReturnsAllRowsAsMaps(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id", "name"}
+	stubRows = [][]driver.Value{
+		{int64(1), []byte("John")},
+		{int64(2), []byte("Jane")},
+	}
+
+	pg := &dialect.PostgresDialect{}
+	rows, err := NewSelectBuilder([]string{"*"}, pg, db, nil).
+		From("users").Where("active", true).All()
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0]["id"] != int64(1) || rows[0]["name"] != "John" {
+		t.Errorf("rows[0] = %v, want id=1 name=John", rows[0])
+	}
+	if rows[1]["id"] != int64(2) || rows[1]["name"] != "Jane" {
+		t.Errorf("rows[1] = %v, want id=2 name=Jane", rows[1])
+	}
+	if strings.Contains(stubLastQuery, "LIMIT") {
+		t.Errorf("query %q should not have a LIMIT", stubLastQuery)
+	}
+}
+
+func TestAll_NoRows(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id"}
+	stubRows = nil
+
+	pg := &dialect.PostgresDialect{}
+	rows, err := NewSelectBuilder(nil, pg, db, nil).From("users").All()
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("rows = %v, want none", rows)
+	}
+}
+
+// --- Aggregate tests ---
+
+func TestCount_ReturnsScalar(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"count"}
+	stubRows = [][]driver.Value{{int64(42)}}
+
+	pg := &dialect.PostgresDialect{}
+	n, err := NewSelectBuilder(nil, pg, db, nil).
+		From("users").Where("active", true).Count()
+	if err != nil {
+		t.Fatalf("Count() error: %v", err)
+	}
+	if n != 42 {
+		t.Errorf("Count() = %d, want 42", n)
+	}
+	if stubLastQuery != `SELECT COUNT(*) FROM "users" WHERE "active" = $1;` {
+		t.Errorf("query = %q", stubLastQuery)
+	}
+}
+
+func TestSum_NullReturnsZero(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"sum"}
+	stubRows = [][]driver.Value{{nil}}
+
+	pg := &dialect.PostgresDialect{}
+	total, err := NewSelectBuilder(nil, pg, db, nil).From("orders").Sum("amount")
+	if err != nil {
+		t.Fatalf("Sum() error: %v", err)
+	}
+	if total != 0 {
+		t.Errorf("Sum() on NULL = %v, want 0", total)
+	}
+	if stubLastQuery != `SELECT SUM("amount") FROM "orders";` {
+		t.Errorf("query = %q", stubLastQuery)
+	}
+}
+
+func TestAvg_ReturnsFloat(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"avg"}
+	stubRows = [][]driver.Value{{float64(3.5)}}
+
+	pg := &dialect.PostgresDialect{}
+	avg, err := NewSelectBuilder(nil, pg, db, nil).From("reviews").Avg("rating")
+	if err != nil {
+		t.Fatalf("Avg() error: %v", err)
+	}
+	if avg != 3.5 {
+		t.Errorf("Avg() = %v, want 3.5", avg)
+	}
+}
+
+func TestMin_ConvertsBytesToString(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"min"}
+	stubRows = [][]driver.Value{{[]byte("alice")}}
+
+	pg := &dialect.PostgresDialect{}
+	min, err := NewSelectBuilder(nil, pg, db, nil).From("users").Min("name")
+	if err != nil {
+		t.Fatalf("Min() error: %v", err)
+	}
+	if min != "alice" {
+		t.Errorf("Min() = %v (%T), want string \"alice\"", min, min)
+	}
+}
+
+func TestMax_NullReturnsNil(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"max"}
+	stubRows = [][]driver.Value{{nil}}
+
+	pg := &dialect.PostgresDialect{}
+	max, err := NewSelectBuilder(nil, pg, db, nil).From("users").Max("age")
+	if err != nil {
+		t.Fatalf("Max() error: %v", err)
+	}
+	if max != nil {
+		t.Errorf("Max() on NULL = %v, want nil", max)
+	}
+}
+
+func TestAggregate_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).From("users").Sum("")
+	if err == nil || !strings.Contains(err.Error(), "requires a column") {
+		t.Errorf("expected column-required error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).Count()
+	if err == nil || !strings.Contains(err.Error(), "no table specified") {
+		t.Errorf("expected no-table error, got %v", err)
+	}
+
+	_, err = Select().From("users").Count()
+	if err == nil || !strings.Contains(err.Error(), "no database connection") {
+		t.Errorf("expected no-connection error, got %v", err)
+	}
+}
+
+// --- Increment / Decrement tests ---
+
+func TestIncrement_DefaultAmount(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewUpdateBuilder("posts", nil, pg, nil, nil).
+		Increment("views").Where("id", 10).ToSQL()
+	want := `UPDATE "posts" SET "views" = "views" + 1 WHERE "id" = $1;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 10 {
+		t.Errorf("args = %v, want [10]", args)
+	}
+}
+
+func TestDecrement_ExplicitAmount_MySQL(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sql, args := NewUpdateBuilder("accounts", nil, my, nil, nil).
+		Decrement("balance", 50).Where("id", 3).ToSQL()
+	want := "UPDATE `accounts` SET `balance` = `balance` - 50 WHERE `id` = ?;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 3 {
+		t.Errorf("args = %v, want [3]", args)
+	}
+}
+
+func TestIncrement_MixedWithData_ParamNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewUpdateBuilder("posts", []any{"title", "hi"}, pg, nil, nil).
+		Increment("views", 5).Where("id", 10).ToSQL()
+	// set keys are sorted: title before views; the raw increment consumes no param
+	want := `UPDATE "posts" SET "title" = $1, "views" = "views" + 5 WHERE "id" = $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "hi" || args[1] != 10 {
+		t.Errorf("args = %v, want [hi 10]", args)
+	}
+}
+
+func TestIncrement_NoDialectDefersError(t *testing.T) {
+	_, err := NewUpdateBuilder("posts", nil, nil, &recordingExecer{}, nil).
+		Increment("views").Exec()
+	if err == nil || !strings.Contains(err.Error(), "no dialect") {
+		t.Errorf("expected no-dialect error, got %v", err)
+	}
+}
+
+// --- Update data-form tests ---
+
+func TestUpdate_MapForm(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewUpdateBuilder("users", []any{map[string]any{"name": "Alice", "age": 30}}, pg, nil, nil).
+		Where("id", 1).ToSQL()
+	want := `UPDATE "users" SET "age" = $1, "name" = $2 WHERE "id" = $3;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != 30 || args[1] != "Alice" || args[2] != 1 {
+		t.Errorf("args = %v, want [30 Alice 1]", args)
+	}
+}
+
+func TestUpdate_MapForm_CallerMapNotMutated(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	data := map[string]any{"title": "hi"}
+	NewUpdateBuilder("posts", []any{data}, pg, nil, nil).Increment("views")
+	if len(data) != 1 {
+		t.Errorf("caller map mutated: %v", data)
+	}
+}
+
+func TestUpdate_StructForm(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	type user struct {
+		FullName string `db:"name"`
+		Age      int
+		Secret   string `db:"-"`
+		internal bool
+	}
+	sql, args := NewUpdateBuilder("users", []any{user{FullName: "Alice", Secret: "x"}}, pg, nil, nil).
+		Where("id", 1).ToSQL()
+	// db tag, snake_case fallback, db:"-" and unexported skipped;
+	// zero-valued Age is included.
+	want := `UPDATE "users" SET "age" = $1, "name" = $2 WHERE "id" = $3;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != 0 || args[1] != "Alice" || args[2] != 1 {
+		t.Errorf("args = %v, want [0 Alice 1]", args)
+	}
+}
+
+func TestUpdate_PairForm(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewUpdateBuilder("books", []any{"title", "Slaughterhouse Five"}, pg, nil, nil).
+		Where("id", 42).ToSQL()
+	want := `UPDATE "books" SET "title" = $1 WHERE "id" = $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "Slaughterhouse Five" || args[1] != 42 {
+		t.Errorf("args = %v, want [Slaughterhouse Five 42]", args)
+	}
+}
+
+func TestUpdate_DataErrors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewUpdateBuilder("users", []any{42}, pg, &recordingExecer{}, nil).Exec()
+	if err == nil || !strings.Contains(err.Error(), "Update expects") {
+		t.Errorf("expected data type error, got %v", err)
+	}
+
+	_, err = NewUpdateBuilder("users", []any{7, "x"}, pg, &recordingExecer{}, nil).Exec()
+	if err == nil || !strings.Contains(err.Error(), "column must be a string") {
+		t.Errorf("expected column type error, got %v", err)
+	}
+
+	_, err = NewUpdateBuilder("users", []any{"a", 1, "b"}, pg, &recordingExecer{}, nil).Exec()
+	if err == nil || !strings.Contains(err.Error(), "Update expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+
+	_, err = NewUpdateBuilder("users", nil, pg, &recordingExecer{}, nil).Exec()
+	if err == nil || !strings.Contains(err.Error(), "no values to update") {
+		t.Errorf("expected empty-set error, got %v", err)
+	}
+}
+
+// --- WhereNot tests ---
+
+func TestWhereNot_BuildsNegatedSQL(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").WhereNot("role", "admin").ToSQL()
+	want := `SELECT * FROM "users" WHERE NOT "role" = $1;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != "admin" {
+		t.Errorf("args = %v, want [admin]", args)
+	}
+}
+
+func TestWhereNot_GroupAndOrForms(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		Where("active", true).
+		WhereNot(func(g *WhereGroup) {
+			g.Where("role", "admin").OrWhereNot("age", ">", 65)
+		}).
+		OrWhereNot("plan", "free").
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE "active" = $1 AND NOT ("role" = $2 OR NOT "age" > $3) OR NOT "plan" = $4;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 4 {
+		t.Errorf("args = %v, want 4 args", args)
+	}
+}
+
+func TestWhereNot_OnUpdateAndDelete(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewUpdateBuilder("users", []any{"active", false}, pg, nil, nil).
+		WhereNot("role", "admin").ToSQL()
+	want := `UPDATE "users" SET "active" = $1 WHERE NOT "role" = $2;`
+	if sql != want {
+		t.Errorf("update SQL = %q, want %q", sql, want)
+	}
+
+	sql, _ = NewDeleteBuilder("users", pg, nil, nil).
+		WhereNot("protected", true).ToSQL()
+	want = `DELETE FROM "users" WHERE NOT "protected" = $1;`
+	if sql != want {
+		t.Errorf("delete SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWhereNot_WrongArityDefersError(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereNot("only-one").Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+}
+
+// --- Or-variant tests ---
+
+func TestOrVariants_JoinWithOr(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		Where("active", true).
+		OrWhereIn("status", "vip", "staff").
+		OrWhereNotIn("plan", "free").
+		OrWhereNull("deleted_at").
+		OrWhereNotNull("verified_at").
+		OrWhereRaw("lower(name) = ?", "john").
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE "active" = $1` +
+		` OR "status" IN ($2, $3)` +
+		` OR "plan" NOT IN ($4)` +
+		` OR "deleted_at" IS NULL` +
+		` OR "verified_at" IS NOT NULL` +
+		` OR lower(name) = $5;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 5 {
+		t.Errorf("args = %v, want 5 args", args)
+	}
+}
+
+func TestOrVariants_InsideGroup(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewDeleteBuilder("users", pg, nil, nil).
+		Where(func(g *WhereGroup) {
+			g.WhereNull("deleted_at").
+				OrWhereIn("status", "banned").
+				OrWhereNotNull("purged_at").
+				OrWhereRaw("age < ?", 13)
+		}).
+		ToSQL()
+	want := `DELETE FROM "users" WHERE ("deleted_at" IS NULL OR "status" IN ($1) OR "purged_at" IS NOT NULL OR age < $2);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestOrVariants_OnUpdate(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewUpdateBuilder("users", []any{"active", false}, pg, nil, nil).
+		WhereNull("confirmed_at").
+		OrWhereNotIn("role", "admin", "owner").
+		ToSQL()
+	want := `UPDATE "users" SET "active" = $1 WHERE "confirmed_at" IS NULL OR "role" NOT IN ($2, $3);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestOrWhereRaw_ArgCountMismatchDefersError(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").OrWhereRaw("a = ? AND b = ?", 1).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+}
+
+// --- Between / Exists tests ---
+
+func TestWhereBetween_Variants(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		WhereBetween("age", 18, 65).
+		OrWhereNotBetween("score", 0, 50).
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE "age" BETWEEN $1 AND $2 OR "score" NOT BETWEEN $3 AND $4;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 4 || args[0] != 18 || args[3] != 50 {
+		t.Errorf("args = %v, want [18 65 0 50]", args)
+	}
+}
+
+func TestWhereExists_SubBuilder(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sub := Select("1").From("orders").
+		WhereRaw("orders.user_id = users.id").
+		Where("status", "paid")
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		Where("active", true).
+		WhereExists(sub).
+		Where("plan", "pro").
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE "active" = $1 AND EXISTS (SELECT "1" FROM "orders" WHERE orders.user_id = users.id AND "status" = $2) AND "plan" = $3;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != true || args[1] != "paid" || args[2] != "pro" {
+		t.Errorf("args = %v, want [true paid pro]", args)
+	}
+}
+
+func TestWhereNotExists_RawForm(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewDeleteBuilder("users", pg, nil, nil).
+		WhereNotExists("SELECT 1 FROM orders WHERE user_id = users.id AND status = ?", "open").
+		ToSQL()
+	want := `DELETE FROM "users" WHERE NOT EXISTS (SELECT 1 FROM orders WHERE user_id = users.id AND status = $1);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != "open" {
+		t.Errorf("args = %v, want [open]", args)
+	}
+}
+
+func TestWhereExists_InGroupAndOrVariants(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewUpdateBuilder("users", []any{"active", false}, pg, nil, nil).
+		Where(func(g *WhereGroup) {
+			g.WhereBetween("age", 0, 12).
+				OrWhereExists(Select("1").From("bans").WhereRaw("bans.user_id = users.id"))
+		}).
+		OrWhereNotExists("SELECT 1 FROM payments WHERE user_id = users.id").
+		ToSQL()
+	want := `UPDATE "users" SET "active" = $1 WHERE ("age" BETWEEN $2 AND $3 OR EXISTS (SELECT "1" FROM "bans" WHERE bans.user_id = users.id)) OR NOT EXISTS (SELECT 1 FROM payments WHERE user_id = users.id);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWhereExists_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	// raw form: placeholder/arg mismatch
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereExists("SELECT 1 WHERE a = ? AND b = ?", 1).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+
+	// unsupported subquery type
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereExists(42).Exec()
+	if err == nil || !strings.Contains(err.Error(), "expects a *SelectBuilder or a raw SQL string") {
+		t.Errorf("expected type error, got %v", err)
+	}
+
+	// sub-builder without From()
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereExists(Select("1")).Exec()
+	if err == nil || !strings.Contains(err.Error(), "call From()") {
+		t.Errorf("expected missing-From error, got %v", err)
+	}
+
+	// args passed alongside a builder subquery
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereExists(Select("1").From("orders"), "stray").Exec()
+	if err == nil || !strings.Contains(err.Error(), "raw SQL subquery") {
+		t.Errorf("expected stray-args error, got %v", err)
+	}
+
+	// deferred error inside the sub-builder propagates
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").WhereExists(Select("1").From("orders").Where("bad-arity")).Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected propagated sub-builder error, got %v", err)
+	}
+}
+
+// --- Like / ILike tests ---
+
+func TestWhereLike_Variants(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		WhereLike("name", "Jo%").
+		OrWhereILike("email", "%@x.com").
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE "name" LIKE $1 OR "email" ILIKE $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "Jo%" || args[1] != "%@x.com" {
+		t.Errorf("args = %v, want [Jo%% %%@x.com]", args)
+	}
+}
+
+func TestWhereILike_MySQLAndGroup(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sql, _ := NewDeleteBuilder("users", my, nil, nil).
+		Where(func(g *WhereGroup) {
+			g.WhereILike("name", "spam%").OrWhereLike("email", "Bot@%")
+		}).
+		ToSQL()
+	want := "DELETE FROM `users` WHERE (`name` LIKE ? OR `email` LIKE BINARY ?);"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWhereLike_OnUpdateParamNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewUpdateBuilder("users", []any{"flagged", true}, pg, nil, nil).
+		WhereILike("bio", "%crypto%").
+		ToSQL()
+	want := `UPDATE "users" SET "flagged" = $1 WHERE "bio" ILIKE $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[1] != "%crypto%" {
+		t.Errorf("args = %v, want [true %%crypto%%]", args)
+	}
+}
+
+// --- Distinct / GroupBy tests ---
+
+func TestDistinctAndGroupBy_Chain(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From("orders").
+		Distinct().
+		Where("total", ">", 100).
+		GroupBy("status", "region").
+		GroupByRaw("DATE(created_at)").
+		OrderBy("status").
+		ToSQL()
+	want := `SELECT DISTINCT * FROM "orders" WHERE "total" > $1 GROUP BY "status", "region", DATE(created_at) ORDER BY "status";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 100 {
+		t.Errorf("args = %v, want [100]", args)
+	}
+}
+
+func TestDistinct_WithColumnsSetsSelectList(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").Distinct("city", "state").ToSQL()
+	want := `SELECT DISTINCT "city", "state" FROM "users";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestDistinctOn_Postgres(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("logins").
+		DistinctOn("user_id").
+		OrderBy("user_id").
+		OrderBy("created_at", "desc").
+		ToSQL()
+	want := `SELECT DISTINCT ON ("user_id") * FROM "logins" ORDER BY "user_id", "created_at" DESC;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestDistinctOn_Errors(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, my, &recordingExecer{}, nil).
+		From("logins").DistinctOn("user_id").Exec()
+	if err == nil || !strings.Contains(err.Error(), "not supported by mysql") {
+		t.Errorf("expected mysql unsupported error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("logins").DistinctOn().Exec()
+	if err == nil || !strings.Contains(err.Error(), "at least one column") {
+		t.Errorf("expected no-columns error, got %v", err)
+	}
+}
+
+func TestWhereExists_SubqueryCarriesGroupBy(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("users").
+		WhereExists(
+			Select("user_id").From("orders").
+				WhereRaw("orders.user_id = users.id").
+				GroupBy("user_id"),
+		).
+		ToSQL()
+	want := `SELECT * FROM "users" WHERE EXISTS (SELECT "user_id" FROM "orders" WHERE orders.user_id = users.id GROUP BY "user_id");`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+// --- From subquery / As tests ---
+
+func TestFromSubquery_Postgres_ParamNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sub := Select("user_id").From("orders").Where("status", "paid").GroupBy("user_id").As("t")
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		From(sub).
+		Where("user_id", ">", 10).
+		ToSQL()
+	want := `SELECT * FROM (SELECT "user_id" FROM "orders" WHERE "status" = $1 GROUP BY "user_id") AS "t" WHERE "user_id" > $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "paid" || args[1] != 10 {
+		t.Errorf("args = %v, want [paid 10]", args)
+	}
+}
+
+func TestFromSubquery_MySQL(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sub := Select("user_id").From("orders").Where("total", ">", 100).As("big")
+	sql, args := NewSelectBuilder([]string{"user_id"}, my, nil, nil).
+		From(sub).
+		ToSQL()
+	want := "SELECT `user_id` FROM (SELECT `user_id` FROM `orders` WHERE `total` > ?) AS `big`;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 100 {
+		t.Errorf("args = %v, want [100]", args)
+	}
+}
+
+func TestFromSubquery_HavingNumberingAfterFromArgs(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sub := Select("user_id").From("orders").Where("status", "paid").As("t")
+	sql, args := NewSelectBuilder([]string{"user_id"}, pg, nil, nil).
+		From(sub).
+		GroupBy("user_id").
+		Having("count", ">", 5).
+		ToSQL()
+	want := `SELECT "user_id" FROM (SELECT "user_id" FROM "orders" WHERE "status" = $1) AS "t" GROUP BY "user_id" HAVING "count" > $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "paid" || args[1] != 5 {
+		t.Errorf("args = %v, want [paid 5]", args)
+	}
+}
+
+func TestFromSubquery_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From(Select("1").From("orders")).Exec() // no As()
+	if err == nil || !strings.Contains(err.Error(), "requires an alias") {
+		t.Errorf("expected missing-alias error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From(Select("1").As("t")).Exec() // subquery has no table
+	if err == nil || !strings.Contains(err.Error(), "has no table") {
+		t.Errorf("expected no-table error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From(42).Exec()
+	if err == nil || !strings.Contains(err.Error(), "From expects") {
+		t.Errorf("expected type error, got %v", err)
+	}
+
+	sub := Select("user_id").From("orders").As("t")
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From(sub).Count()
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected aggregate-unsupported error, got %v", err)
+	}
+}
+
+// --- Having tests ---
+
+func TestHaving_ComparisonForm(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		Having("count", ">", 5).
+		ToSQL()
+	want := `SELECT "status" FROM "orders" GROUP BY "status" HAVING "count" > $1;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 5 {
+		t.Errorf("args = %v, want [5]", args)
+	}
+}
+
+func TestHavingRaw_And_FullChainNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		Where("region", "eu").
+		GroupBy("status").
+		Having("count", ">", 5).
+		HavingRaw("SUM(total) < ?", 999).
+		OrderBy("status").
+		ToSQL()
+	want := `SELECT "status" FROM "orders" WHERE "region" = $1 GROUP BY "status" HAVING "count" > $2 AND SUM(total) < $3 ORDER BY "status";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != "eu" || args[1] != 5 || args[2] != 999 {
+		t.Errorf("args = %v, want [eu 5 999]", args)
+	}
+}
+
+func TestHavingIn_And_NotIn(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		HavingIn("status", []string{"open", "paid"}).
+		ToSQL()
+	want := `SELECT "status" FROM "orders" GROUP BY "status" HAVING "status" IN ($1, $2);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "open" || args[1] != "paid" {
+		t.Errorf("args = %v, want [open paid]", args)
+	}
+
+	sql, args = NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		HavingNotIn("status", "void", "failed").
+		ToSQL()
+	want = `SELECT "status" FROM "orders" GROUP BY "status" HAVING "status" NOT IN ($1, $2);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "void" || args[1] != "failed" {
+		t.Errorf("args = %v, want [void failed]", args)
+	}
+}
+
+func TestHavingNull_And_NotNull(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		HavingNull("closed_at").
+		HavingNotNull("status").
+		ToSQL()
+	want := `SELECT "status" FROM "orders" GROUP BY "status" HAVING "closed_at" IS NULL AND "status" IS NOT NULL;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("args = %v, want none", args)
+	}
+}
+
+func TestHavingBetween_NumberingAfterWhere(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		Where("region", "eu").
+		GroupBy("status").
+		HavingBetween("total", 10, 100).
+		HavingNotBetween("count", 0, 2).
+		ToSQL()
+	want := `SELECT "status" FROM "orders" WHERE "region" = $1 GROUP BY "status" HAVING "total" BETWEEN $2 AND $3 AND "count" NOT BETWEEN $4 AND $5;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 5 || args[0] != "eu" || args[1] != 10 || args[2] != 100 || args[3] != 0 || args[4] != 2 {
+		t.Errorf("args = %v, want [eu 10 100 0 2]", args)
+	}
+}
+
+func TestHavingExists_And_NotExists(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, args := NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		HavingExists(
+			Select("1").From("refunds").WhereRaw("refunds.status = orders.status"),
+		).
+		ToSQL()
+	want := `SELECT "status" FROM "orders" GROUP BY "status" HAVING EXISTS (SELECT "1" FROM "refunds" WHERE refunds.status = orders.status);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 0 {
+		t.Errorf("args = %v, want none", args)
+	}
+
+	sql, args = NewSelectBuilder([]string{"status"}, pg, nil, nil).
+		From("orders").
+		GroupBy("status").
+		HavingNotExists("SELECT 1 FROM audits WHERE audits.kind = ?", "fraud").
+		ToSQL()
+	want = `SELECT "status" FROM "orders" GROUP BY "status" HAVING NOT EXISTS (SELECT 1 FROM audits WHERE audits.kind = $1);`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != "fraud" {
+		t.Errorf("args = %v, want [fraud]", args)
+	}
+}
+
+func TestHavingExists_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("orders").GroupBy("status").HavingExists(42).Exec()
+	if err == nil || !strings.Contains(err.Error(), "expects a *SelectBuilder") {
+		t.Errorf("expected subquery type error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("orders").GroupBy("status").
+		HavingNotExists("SELECT 1 WHERE a = ? AND b = ?", 1).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+}
+
+func TestHaving_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("orders").GroupBy("status").Having("only-one").Exec()
+	if err == nil || !strings.Contains(err.Error(), "Where expects") {
+		t.Errorf("expected arity error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("orders").HavingRaw("COUNT(*) > ? AND SUM(x) > ?", 5).Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+}

--- a/query/builder_test.go
+++ b/query/builder_test.go
@@ -1044,6 +1044,180 @@ func TestWhereExists_SubqueryCarriesGroupBy(t *testing.T) {
 	}
 }
 
+// --- WithSchema tests ---
+
+func TestWithSchema_SelectFromAndJoins(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		WithSchema("analytics").
+		From("events as e").
+		Join("orders as o", "e.order_id", "o.id").
+		JoinRaw("LEFT JOIN raw_t ON raw_t.id = e.id").
+		ToSQL()
+	want := `SELECT * FROM "analytics"."events" AS "e" INNER JOIN "analytics"."orders" AS "o" ON "e"."order_id" = "o"."id" LEFT JOIN raw_t ON raw_t.id = e.id;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestWithSchema_OtherBuilders(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	my := &dialect.MySQLDialect{}
+
+	sql, _ := NewUpdateBuilder("users", []any{"active", false}, pg, nil, nil).
+		WithSchema("crm").Where("id", 1).ToSQL()
+	if want := `UPDATE "crm"."users" SET "active" = $1 WHERE "id" = $2;`; sql != want {
+		t.Errorf("update SQL = %q, want %q", sql, want)
+	}
+
+	sql, _ = NewDeleteBuilder("users", my, nil, nil).WithSchema("crm").ToSQL()
+	if want := "DELETE FROM `crm`.`users`;"; sql != want {
+		t.Errorf("delete SQL = %q, want %q", sql, want)
+	}
+
+	sql, _ = NewTruncateBuilder("sessions", pg, nil, nil).WithSchema("crm").ToSQL()
+	if want := `TRUNCATE TABLE "crm"."sessions";`; sql != want {
+		t.Errorf("truncate SQL = %q, want %q", sql, want)
+	}
+
+	sql, _ = NewInsertBuilder(map[string]any{"name": "x"}, pg, nil, nil).
+		Into("users").WithSchema("crm").ToSQL()
+	if !strings.HasPrefix(sql, `INSERT INTO "crm"."users"`) {
+		t.Errorf("insert SQL = %q, want INSERT INTO \"crm\".\"users\" prefix", sql)
+	}
+}
+
+// --- Column alias tests ---
+
+func TestSelect_ColumnAliases(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder([]string{"name as n", "users.email as e", "*"}, pg, nil, nil).
+		From("users").ToSQL()
+	want := `SELECT "name" AS "n", "users"."email" AS "e", * FROM "users";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+// --- Locking tests ---
+
+func TestForUpdate_And_ForShareModifiers(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sql, _ := NewSelectBuilder(nil, pg, nil, nil).
+		From("jobs").Where("status", "queued").Limit(1).
+		ForUpdate().SkipLocked().
+		ToSQL()
+	want := `SELECT * FROM "jobs" WHERE "status" = $1 LIMIT 1 FOR UPDATE SKIP LOCKED;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+
+	sql, _ = NewSelectBuilder(nil, pg, nil, nil).
+		From("accounts").ForShare().NoWait().ToSQL()
+	want = `SELECT * FROM "accounts" FOR SHARE NOWAIT;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+}
+
+func TestLockModifier_RequiresLock(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("jobs").SkipLocked().Exec()
+	if err == nil || !strings.Contains(err.Error(), "SkipLocked requires") {
+		t.Errorf("expected modifier error, got %v", err)
+	}
+}
+
+// --- CTE tests ---
+
+func TestWith_BuilderForm_ParamNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	totals := Select("user_id").From("orders").Where("status", "paid").GroupBy("user_id")
+	sql, args := NewSelectBuilder(nil, pg, nil, nil).
+		With("totals", totals).
+		From("totals").
+		Where("user_id", ">", 10).
+		ToSQL()
+	want := `WITH "totals" AS (SELECT "user_id" FROM "orders" WHERE "status" = $1 GROUP BY "user_id") SELECT * FROM "totals" WHERE "user_id" > $2;`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 2 || args[0] != "paid" || args[1] != 10 {
+		t.Errorf("args = %v, want [paid 10]", args)
+	}
+}
+
+func TestWithRecursive_RawForm_MultipleCTEs(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sql, args := NewSelectBuilder(nil, my, nil, nil).
+		WithRecursive("nums", "SELECT 1 AS n UNION ALL SELECT n + 1 FROM nums WHERE n < ?", 10).
+		With("labels", "SELECT 'x' AS label").
+		From("nums").
+		ToSQL()
+	want := "WITH RECURSIVE `nums` AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM nums WHERE n < ?), `labels` AS (SELECT 'x' AS label) SELECT * FROM `nums`;"
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 1 || args[0] != 10 {
+		t.Errorf("args = %v, want [10]", args)
+	}
+}
+
+func TestWith_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		With("t", 42).From("t").Exec()
+	if err == nil || !strings.Contains(err.Error(), "With expects") {
+		t.Errorf("expected type error, got %v", err)
+	}
+
+	_, err = NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		With("t", "SELECT ? AND ?", 1).From("t").Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+}
+
+// --- Union tests ---
+
+func TestUnion_And_UnionAll_ParamNumbering(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	archived := Select("name").From("archived_users").Where("deleted_at", ">", "2020-01-01")
+	sql, args := NewSelectBuilder([]string{"name"}, pg, nil, nil).
+		From("users").
+		Where("active", true).
+		Union(archived).
+		UnionAll("SELECT name FROM invited_users WHERE invited_by = ?", 7).
+		OrderBy("name").
+		ToSQL()
+	want := `SELECT "name" FROM "users" WHERE "active" = $1 UNION SELECT "name" FROM "archived_users" WHERE "deleted_at" > $2 UNION ALL SELECT name FROM invited_users WHERE invited_by = $3 ORDER BY "name";`
+	if sql != want {
+		t.Errorf("SQL = %q, want %q", sql, want)
+	}
+	if len(args) != 3 || args[0] != true || args[1] != "2020-01-01" || args[2] != 7 {
+		t.Errorf("args = %v, want [true 2020-01-01 7]", args)
+	}
+}
+
+func TestUnion_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewSelectBuilder(nil, pg, &recordingExecer{}, nil).
+		From("users").Union(Select("1")).Exec() // subquery has no table
+	if err == nil || !strings.Contains(err.Error(), "has no table") {
+		t.Errorf("expected no-table error, got %v", err)
+	}
+}
+
 // --- Join tests ---
 
 func TestJoin_InnerWithAliasAndQualifiedColumns(t *testing.T) {

--- a/query/insert.go
+++ b/query/insert.go
@@ -20,6 +20,7 @@ type Execer interface {
 type InsertBuilder struct {
 	data             any
 	table            string
+	schemaName       string
 	dialect          dialect.Dialect
 	execer           Execer
 	err              error // deferred error (e.g. from lazy connection)
@@ -65,6 +66,12 @@ func (i *InsertBuilder) Into(table string) *InsertBuilder {
 	return i
 }
 
+// WithSchema qualifies the insert's table with a schema name.
+func (i *InsertBuilder) WithSchema(name string) *InsertBuilder {
+	i.schemaName = name
+	return i
+}
+
 // build normalizes the insert data and generates the SQL and args.
 // returning columns are appended as a RETURNING clause where supported.
 func (i *InsertBuilder) build(returning []string) (string, []any, error) {
@@ -80,13 +87,13 @@ func (i *InsertBuilder) build(returning []string) (string, []any, error) {
 		if len(data) == 0 {
 			return "", nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertSQL(i.table, data, opts)
+		query, args := i.dialect.InsertSQL(prefixSchema(i.schemaName, i.table), data, opts)
 		return query, args, nil
 	case []map[string]any:
 		if len(data) == 0 {
 			return "", nil, fmt.Errorf("no data to insert")
 		}
-		query, args := i.dialect.InsertManySQL(i.table, data, opts)
+		query, args := i.dialect.InsertManySQL(prefixSchema(i.schemaName, i.table), data, opts)
 		return query, args, nil
 	default:
 		rv := reflect.ValueOf(i.data)
@@ -102,7 +109,7 @@ func (i *InsertBuilder) build(returning []string) (string, []any, error) {
 			if len(m) == 0 {
 				return "", nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertSQL(i.table, m, opts)
+			query, args := i.dialect.InsertSQL(prefixSchema(i.schemaName, i.table), m, opts)
 			return query, args, nil
 		case reflect.Slice:
 			maps, err := structsToMaps(i.data)
@@ -112,7 +119,7 @@ func (i *InsertBuilder) build(returning []string) (string, []any, error) {
 			if len(maps) == 0 {
 				return "", nil, fmt.Errorf("no data to insert")
 			}
-			query, args := i.dialect.InsertManySQL(i.table, maps, opts)
+			query, args := i.dialect.InsertManySQL(prefixSchema(i.schemaName, i.table), maps, opts)
 			return query, args, nil
 		default:
 			return "", nil, fmt.Errorf("Insert expects map[string]any, []map[string]any, struct, or []struct, got %T", i.data)

--- a/query/insert_test.go
+++ b/query/insert_test.go
@@ -95,8 +95,8 @@ func TestExecReturning_UpdateAndDelete(t *testing.T) {
 
 	pg := &dialect.PostgresDialect{}
 
-	rows, err := NewUpdateBuilder("users", pg, db, nil).
-		Set("active", false).Where("age", ">", 90).ExecReturning("id", "name")
+	rows, err := NewUpdateBuilder("users", []any{"active", false}, pg, db, nil).
+		Where("age", ">", 90).ExecReturning("id", "name")
 	if err != nil {
 		t.Fatalf("update ExecReturning() error: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestExecReturning_Errors(t *testing.T) {
 	}
 
 	// Update's empty-SET guard still applies.
-	_, err = NewUpdateBuilder("users", pg, db, nil).Where("id", 1).ExecReturning("id")
+	_, err = NewUpdateBuilder("users", nil, pg, db, nil).Where("id", 1).ExecReturning("id")
 	if err == nil || !strings.Contains(err.Error(), "no values to update") {
 		t.Errorf("expected empty-SET error, got %v", err)
 	}

--- a/query/raw.go
+++ b/query/raw.go
@@ -1,0 +1,73 @@
+package query
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+// RawBuilder runs a raw SQL statement with ? placeholders bound to args,
+// rebound to the dialect's placeholder style ($n on PostgreSQL).
+type RawBuilder struct {
+	raw     string
+	args    []any
+	dialect dialect.Dialect
+	execer  Execer
+	err     error
+}
+
+// NewRawBuilder creates a dialect-aware RawBuilder (used by Schema).
+func NewRawBuilder(raw string, args []any, d dialect.Dialect, execer Execer, err error) *RawBuilder {
+	b := &RawBuilder{raw: raw, args: args, dialect: d, execer: execer, err: err}
+	if n := strings.Count(raw, "?"); n != len(args) && b.err == nil {
+		b.err = fmt.Errorf("RawQuery has %d placeholders but %d args", n, len(args))
+	}
+	return b
+}
+
+// ToSQL returns the statement with placeholders rebound and its args.
+func (r *RawBuilder) ToSQL() (string, []any) {
+	if r.dialect == nil {
+		return "", nil
+	}
+	return r.dialect.RawSQL(r.raw, r.args)
+}
+
+// check validates the builder state before execution.
+func (r *RawBuilder) check() error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.execer == nil {
+		return fmt.Errorf("no database connection")
+	}
+	return nil
+}
+
+// Exec executes the statement and returns the result. Use for statements
+// that don't return rows (UPDATE, DELETE, DDL).
+func (r *RawBuilder) Exec() (sql.Result, error) {
+	if err := r.check(); err != nil {
+		return nil, err
+	}
+	sqlStr, args := r.ToSQL()
+	return r.execer.Exec(sqlStr, args...)
+}
+
+// All executes the query and returns every row as a map keyed by column
+// name. []byte column values are converted to string; no rows yields an
+// empty result, not an error.
+func (r *RawBuilder) All() ([]map[string]any, error) {
+	if err := r.check(); err != nil {
+		return nil, err
+	}
+	sqlStr, args := r.ToSQL()
+	rows, err := r.execer.Query(sqlStr, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanRowMaps(rows)
+}

--- a/query/raw_test.go
+++ b/query/raw_test.go
@@ -1,0 +1,99 @@
+package query
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"strings"
+	"testing"
+
+	"github.com/Grandbusta/jone/dialect"
+)
+
+func TestRawQuery_ToSQL_RebindsPostgres(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	sqlStr, args := NewRawBuilder("SELECT * FROM users WHERE age > ? AND status = ?", []any{21, "active"}, pg, nil, nil).
+		ToSQL()
+	want := "SELECT * FROM users WHERE age > $1 AND status = $2"
+	if sqlStr != want {
+		t.Errorf("SQL = %q, want %q", sqlStr, want)
+	}
+	if len(args) != 2 || args[0] != 21 || args[1] != "active" {
+		t.Errorf("args = %v, want [21 active]", args)
+	}
+}
+
+func TestRawQuery_ToSQL_MySQLKeepsQuestionMarks(t *testing.T) {
+	my := &dialect.MySQLDialect{}
+
+	sqlStr, args := NewRawBuilder("SELECT * FROM users WHERE age > ?", []any{21}, my, nil, nil).
+		ToSQL()
+	want := "SELECT * FROM users WHERE age > ?"
+	if sqlStr != want {
+		t.Errorf("SQL = %q, want %q", sqlStr, want)
+	}
+	if len(args) != 1 || args[0] != 21 {
+		t.Errorf("args = %v, want [21]", args)
+	}
+}
+
+func TestRawQuery_Exec_PassesReboundArgs(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+	rec := &recordingExecer{}
+
+	_, err := NewRawBuilder("UPDATE users SET status = ? WHERE id = ?", []any{"legacy", 7}, pg, rec, nil).
+		Exec()
+	if err != nil {
+		t.Fatalf("Exec() error: %v", err)
+	}
+	if rec.query != "UPDATE users SET status = $1 WHERE id = $2" {
+		t.Errorf("query = %q", rec.query)
+	}
+	if len(rec.args) != 2 || rec.args[0] != "legacy" || rec.args[1] != 7 {
+		t.Errorf("args = %v, want [legacy 7]", rec.args)
+	}
+}
+
+func TestRawQuery_All_ReturnsRowsAsMaps(t *testing.T) {
+	db, err := sql.Open("jone_stub", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	stubColumns = []string{"id", "name"}
+	stubRows = [][]driver.Value{
+		{int64(1), []byte("John")},
+		{int64(2), []byte("Jane")},
+	}
+
+	pg := &dialect.PostgresDialect{}
+	rows, err := NewRawBuilder("SELECT * FROM users WHERE age > ?", []any{21}, pg, db, nil).All()
+	if err != nil {
+		t.Fatalf("All() error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+	if rows[0]["name"] != "John" || rows[1]["name"] != "Jane" {
+		t.Errorf("rows = %v, want John and Jane", rows)
+	}
+	if stubLastQuery != "SELECT * FROM users WHERE age > $1" {
+		t.Errorf("query = %q, want rebound placeholder", stubLastQuery)
+	}
+}
+
+func TestRawQuery_Errors(t *testing.T) {
+	pg := &dialect.PostgresDialect{}
+
+	_, err := NewRawBuilder("SELECT * FROM users WHERE a = ? AND b = ?", []any{1}, pg, &recordingExecer{}, nil).
+		Exec()
+	if err == nil || !strings.Contains(err.Error(), "placeholders") {
+		t.Errorf("expected placeholder count error, got %v", err)
+	}
+
+	_, err = NewRawBuilder("SELECT 1", nil, pg, nil, nil).All()
+	if err == nil || !strings.Contains(err.Error(), "no database connection") {
+		t.Errorf("expected no-connection error, got %v", err)
+	}
+}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -177,6 +177,18 @@ func (s *Schema) Raw(sqlStmt string, args ...any) {
 	}
 }
 
+// RawQuery starts a raw SQL statement with ? placeholders bound to args,
+// rebound to the dialect's placeholder style. Finish with All() for rows as
+// maps, Exec() for statements without results, or ToSQL() to inspect:
+//
+//	rows, err := db.RawQuery("SELECT * FROM users WHERE age > ?", 21).All()
+//
+// For raw SQL inside migrations, use Raw(), which executes immediately.
+func (s *Schema) RawQuery(sqlStr string, args ...any) *query.RawBuilder {
+	err := s.ensureOpen()
+	return query.NewRawBuilder(sqlStr, args, s.dialect, s.execer, err)
+}
+
 // Insert starts building an INSERT query with the given data.
 // Accepts map[string]any for a single row, or []map[string]any for multiple rows.
 func (s *Schema) Insert(data any) *query.InsertBuilder {
@@ -190,10 +202,13 @@ func (s *Schema) Select(columns ...string) *query.SelectBuilder {
 	return query.NewSelectBuilder(columns, s.dialect, s.execer, err)
 }
 
-// Update starts building an UPDATE query for the given table.
-func (s *Schema) Update(table string) *query.UpdateBuilder {
+// Update starts building an UPDATE query for the given table. The data to
+// set is passed directly: Update(table, map), Update(table, struct) using db
+// tags with snake_case fallback, or Update(table, column, value). The bare
+// Update(table) form is valid when only Increment/Decrement follow.
+func (s *Schema) Update(table string, args ...any) *query.UpdateBuilder {
 	err := s.ensureOpen()
-	return query.NewUpdateBuilder(table, s.dialect, s.execer, err)
+	return query.NewUpdateBuilder(table, args, s.dialect, s.execer, err)
 }
 
 // Delete starts building a DELETE query for the given table.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -217,6 +217,14 @@ func (s *Schema) Delete(table string) *query.DeleteBuilder {
 	return query.NewDeleteBuilder(table, s.dialect, s.execer, err)
 }
 
+// Truncate starts building a TRUNCATE TABLE statement for the given table.
+// TRUNCATE removes all rows; on MySQL it also resets AUTO_INCREMENT and
+// cannot run inside a transaction (it commits implicitly).
+func (s *Schema) Truncate(table string) *query.TruncateBuilder {
+	err := s.ensureOpen()
+	return query.NewTruncateBuilder(table, s.dialect, s.execer, err)
+}
+
 // Transaction runs fn inside a database transaction.
 // Automatically commits on nil return, rolls back on error.
 func (s *Schema) Transaction(fn func(tx *Schema) error) error {


### PR DESCRIPTION
This PR completes the query builder: a full `SelectBuilder` (joins, grouping, aggregations, CTEs, unions, row locking, derived tables), a greatly expanded WHERE/HAVING vocabulary, a knex-style UPDATE API, raw queries, TRUNCATE, and schema-qualified tables. Every feature covered by dialect-level and builder-level tests on both PostgreSQL and MySQL.

## New: SelectBuilder

A fluent SELECT builder, joining the existing Insert/Update/Delete builders:

```go
rows, err := db.Select("users.name", "o.total").From("users").
    Join("orders as o", "users.id", "o.user_id").
    Where("o.total", ">", 100).
    GroupBy("users.name").
    Having("count", ">", 5).
    OrderBy("users.name").
    Limit(10).
    Exec()
```

- **Terminal methods**: `Exec()` (rows), `First()` (single row as `map[string]any`, `sql.ErrNoRows` when empty), `All()` (all rows as `[]map[string]any`), `ToSQL()` (inspection).
- **Aggregations**: `Count()`, `Sum()`, `Avg()`, `Min()`, `Max()` — single-value queries honoring the builder's WHERE clauses; numeric aggregates return 0 on no rows, `Min`/`Max` return nil.
- **Grouping**: `GroupBy` / `GroupByRaw`, `Having` / `HavingRaw` plus the full HAVING family — `HavingIn`/`HavingNotIn`, `HavingNull`/`HavingNotNull`, `HavingBetween`/`HavingNotBetween`, `HavingExists`/`HavingNotExists`.
- **Distinct**: `Distinct(cols...)` and PostgreSQL-only `DistinctOn(cols...)` (capability-checked — clear error on MySQL).
- **Standalone builder**: `jone.Select(...)` re-export for subquery composition without a connection.

## Joins

`Join` (INNER), `LeftJoin`/`LeftOuterJoin`, `RightJoin`/`RightOuterJoin`, `FullOuterJoin` (PostgreSQL-only, capability-checked), `CrossJoin` (no ON), and `JoinRaw` for exotic ON conditions with `?`-bound args.

- Two ON forms: `(table, left, right)` for equality, `(table, left, op, right)` for other operators.
- **Qualified identifiers everywhere**: `QuoteIdentifier` is now dot-aware — `users.id` → `"users"."id"`, `users.*` → `"users".*` — so qualified columns work in Select/Where/GroupBy/OrderBy/Having too.
- **Table aliasing**: `"orders as o"` supported in join tables and `From()` (self-joins).

## CTEs, unions, derived tables

- `With(name, subquery)` / `WithRecursive(...)` — WITH clauses, body as a `*SelectBuilder` or raw SQL with `?` args; multiple CTEs compose, `RECURSIVE` applies once to the list.
- `Union(subquery)` / `UnionAll(...)` — builder or raw form; `OrderBy`/`Limit`/`Offset` apply to the combined result.
- **Derived tables**: `As(alias)` names a builder; `From(sub)` selects from it — `SELECT * FROM (SELECT ...) AS "t"`. Alias is validated (both databases require one). EXISTS subqueries and derived tables nest recursively with correct placeholder numbering throughout (args accumulate in textual order: CTEs → FROM subquery → joins → WHERE → HAVING → unions).

## Row locking

`ForUpdate()` / `ForShare()` with `SkipLocked()` / `NoWait()` modifiers (modifiers require a lock mode first). Enables the classic job-queue claim: `...Where("status", "queued").ForUpdate().SkipLocked().First()`.

## Expanded WHERE family

On Select, Update, and Delete builders **and** inside `WhereGroup` closures, each with `Or` variants:

- `WhereNot` / `OrWhereNot` — negated conditions and groups (`NOT "col" = $1`, `NOT (...)`)
- `WhereBetween` / `WhereNotBetween`
- `WhereExists` / `WhereNotExists` — `*SelectBuilder` or raw-string subqueries, compiled inline with continued placeholder numbering
- `WhereLike` / `WhereILike` — dialect-aware case sensitivity (PG `LIKE`/`ILIKE`; MySQL `LIKE BINARY`/`LIKE`)
- `Or` variants completed for the existing family (`OrWhereIn`, `OrWhereNotIn`, `OrWhereNull`, `OrWhereNotNull`, `OrWhereRaw`)

## UPDATE revamp (breaking)

`Set()` is gone; data goes directly into `Update`:

```go
db.Update("users", map[string]any{"name": "Alice", "updated_at": jone.Fn.Now()}).Where("id", 1).Exec()
db.Update("users", user).Where("id", 1).Exec()   // struct via `db` tags, snake_case fallback
db.Update("books", "title", "Slaughterhouse Five").Where("id", 42).Exec()  // single pair
db.Update("counters").Increment("views").Exec()  // bare form for Increment/Decrement
```

Struct input includes all exported fields (zero values included — consistent with Insert); caller-supplied maps are copied, never mutated. `Increment`/`Decrement` are new and compose with any data form.

## RawQuery and Truncate

- `db.RawQuery("SELECT * FROM users WHERE age > ?", 21)` — builder with `All()` / `Exec()` / `ToSQL()`; `?` placeholders rebound per dialect (`$n` on PG). `Schema.Raw` is untouched, keeping its execute-immediately, fatal-on-error contract that existing migrations depend on.
- `db.Truncate("sessions").Exec()` — `TRUNCATE TABLE`, minimal builder by design (no WHERE possible by construction).

## WithSchema

`WithSchema(name)` on **all five builders** qualifies tables with a schema (`FROM "analytics"."events"`). On SELECT it also covers structured join tables — a deliberate improvement over knex, whose `withSchema` leaves joined tables unqualified.

## Dialect layer

- `SelectSQL` now takes a single neutral `SubSelect` struct instead of a positional parameter list, letting SELECTs compile standalone or inline (EXISTS, derived tables, CTEs, unions) with one code path.
- New `Dialect` interface methods: `AggregateSQL`, `RawSQL`, `TruncateSQL`, `SupportsDistinctOn`, `SupportsFullOuterJoin`.
- Shared compile helpers: `compileJoins`, `rebindRaw` (single `?`-rebinding implementation used by WHERE, joins, CTEs, unions, and RawQuery).

## Breaking changes

Pre-1.0, landing in a minor per the versioning policy:

1. **`UpdateBuilder.Set` removed** — use `Update(table, data)` forms above. `NewUpdateBuilder` signature gained a data argument.
2. **`Dialect.SelectSQL` signature changed** to `SelectSQL(SubSelect)`; new required interface methods (affects only custom dialect implementations).
3. **`QuoteIdentifier` treats dots as qualification** — a column name literally containing a dot would now quote as two identifiers.
4. **`SelectBuilder.From` takes `any`** (string or `*SelectBuilder`) — source-compatible for all string callers.

## Testing

- Dialect-level SQL-generation tables (`select_test.go`, `aggregate_test.go`, expanded `where_test.go`) and builder-level tests for every feature, both dialects, including placeholder-numbering interactions (CTE → FROM-sub → join → WHERE → HAVING → union), error paths (deferred errors surfacing at `Exec`), and a stub `database/sql` driver for row-scanning paths (`First`/`All`/aggregates).
- `go test ./...`, `go vet ./...`, `gofmt` all clean.

## Docs

README query-builder section updated with all new features; version bumped to v0.4.0 in `cmd/jone/cli/version.go`.
